### PR TITLE
Issue branch Resolved 

### DIFF
--- a/config/zones/AE.yaml
+++ b/config/zones/AE.yaml
@@ -87,47 +87,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 14.75293563004043
+        value: 14.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 15.75041742126386
+        value: 15.75
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 16.93125713773701
+        value: 16.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 22.225083366014076
+        value: 22.23
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 23.18452952950505
+        value: 23.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 378.7598234832692
+        value: 378.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 405.38414726061814
+        value: 405.38
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 14.75293563004043
+        value: 14.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 15.75041742126386
+        value: 15.75
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 16.93125713773701
+        value: 16.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 22.225083366014076
+        value: 22.23
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 23.18452952950505
+        value: 23.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 378.7598234832692
+        value: 378.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 405.38414726061814
+        value: 405.38
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/AM.yaml
+++ b/config/zones/AM.yaml
@@ -36,17 +36,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 230.28340825401284
+        value: 230.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 235.97485082659796
+        value: 235.97
     hydro discharge:
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 230.28340825401284
+        value: 230.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 235.97485082659796
+        value: 235.97
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2019 average

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -86,47 +86,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 285.363395238358
+        value: 285.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 329.44972802634084
+        value: 329.45
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 332.0786508705253
+        value: 332.08
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 341.2261716626299
+        value: 341.23
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.00098260074736
+        value: 363.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 408.5182956377465
+        value: 408.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 369.05637296692635
+        value: 369.06
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 285.363395238358
+        value: 285.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 329.44972802634084
+        value: 329.45
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 332.0786508705253
+        value: 332.08
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 341.2261716626299
+        value: 341.23
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.00098260074736
+        value: 363.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 408.5182956377465
+        value: 408.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 369.05637296692635
+        value: 369.06
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -159,31 +159,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 344.4250425042337
+        value: 344.43
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 284.29698092107236
+        value: 284.3
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 281.4347886168625
+        value: 281.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 253.88077810370632
+        value: 253.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 211.98693073763414
+        value: 211.99
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 171.79335782996174
+        value: 171.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 223.85828932878874
+        value: 223.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 233.28880941039804
+        value: 233.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 136.69099475936625
+        value: 136.69
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -214,31 +214,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 344.4250425042337
+        value: 344.43
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 284.29698092107236
+        value: 284.3
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 281.4347886168625
+        value: 281.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 253.88077810370632
+        value: 253.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 211.98693073763414
+        value: 211.99
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 171.79335782996174
+        value: 171.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 223.85828932878874
+        value: 223.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 233.28880941039804
+        value: 233.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 136.69099475936625
+        value: 136.69
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -127,25 +127,25 @@ emissionFactors:
         value: 691.002152965954
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 762.4309173082917
+        value: 762.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 737.2929864099549
+        value: 737.29
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 710.2904642171347
+        value: 710.29
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 669.1441329066203
+        value: 669.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 612.0543754515355
+        value: 612.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 505.00478296703096
+        value: 505.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.22262505721056
+        value: 377.22
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -155,25 +155,25 @@ emissionFactors:
         value: 691.002152965954
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 762.4309173082917
+        value: 762.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 737.2929864099549
+        value: 737.29
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 710.2904642171347
+        value: 710.29
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 669.1441329066203
+        value: 669.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 612.0543754515355
+        value: 612.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 505.00478296703096
+        value: 505.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.22262505721056
+        value: 377.22
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -22,59 +22,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 488.9479607108556
+        value: 488.95
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 488.7556095056752
+        value: 488.76
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 488.8809092164791
+        value: 488.88
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 488.63159101761204
+        value: 488.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 488.54175730266013
+        value: 488.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 488.5392426769572
+        value: 488.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 489.08289163225777
+        value: 489.08
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 489.1661479349893
+        value: 489.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 490.2082790427004
+        value: 490.21
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 488.9479607108556
+        value: 488.95
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 488.7556095056752
+        value: 488.76
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 488.8809092164791
+        value: 488.88
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 488.63159101761204
+        value: 488.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 488.54175730266013
+        value: 488.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 488.5392426769572
+        value: 488.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 489.08289163225777
+        value: 489.08
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 489.1661479349893
+        value: 489.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 490.2082790427004
+        value: 490.21
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -121,25 +121,25 @@ emissionFactors:
         value: 656.6446531766451
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 598.1002354373126
+        value: 598.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 747.5631753834645
+        value: 747.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 692.8007996697759
+        value: 692.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 642.5664022020543
+        value: 642.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 594.4552622337956
+        value: 594.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 560.3321922072455
+        value: 560.33
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 423.56619521734797
+        value: 423.57
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -149,25 +149,25 @@ emissionFactors:
         value: 656.6446531766451
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 598.1002354373126
+        value: 598.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 747.5631753834645
+        value: 747.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 692.8007996697759
+        value: 692.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 642.5664022020543
+        value: 642.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 594.4552622337956
+        value: 594.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 560.3321922072455
+        value: 560.33
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 423.56619521734797
+        value: 423.57
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -115,25 +115,25 @@ emissionFactors:
         value: 195.35045278669472
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 168.38445207800473
+        value: 168.38
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 222.03639725532253
+        value: 222.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 243.7892299550123
+        value: 243.79
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 202.54452745468728
+        value: 202.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.40793999171711
+        value: 183.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 142.616985781414
+        value: 142.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 129.80874421410232
+        value: 129.81
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -143,25 +143,25 @@ emissionFactors:
         value: 195.35045278669472
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 168.38445207800473
+        value: 168.38
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 222.03639725532253
+        value: 222.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 243.7892299550123
+        value: 243.79
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 202.54452745468728
+        value: 202.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.40793999171711
+        value: 183.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 142.616985781414
+        value: 142.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 129.80874421410232
+        value: 129.81
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -36,23 +36,23 @@ emissionFactors:
     battery discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 222.33636187819033
+        value: 222.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 258.84249932990565
+        value: 258.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 236.2236420046538
+        value: 236.22
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 222.33636187819033
+        value: 222.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 258.84249932990565
+        value: 258.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 236.2236420046538
+        value: 236.22
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -43,46 +43,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 126.47864948911594
+        value: 126.48
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 234.82769857383983
+        value: 234.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 343.4562709935645
+        value: 343.46
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 472.5123009269097
+        value: 472.51
     hydro discharge:
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 126.47864948911594
+        value: 126.48
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 234.82769857383983
+        value: 234.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 343.4562709935645
+        value: 343.46
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 472.5123009269097
+        value: 472.51
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.013174835519778237
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.4390433792282261
-        solar: 0.006935215444463839
-        unknown: 0.0
-        wind: 0.5407325094488638
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:
@@ -98,6 +83,21 @@ fallbackZoneMixes:
         solar: 0.011081899897343447
         unknown: 0.0
         wind: 0.6237562282480782
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.013174835519778237
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.4390433792282261
+        solar: 0.006935215444463839
+        unknown: 0.0
+        wind: 0.5407325094488638
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -91,25 +91,25 @@ emissionFactors:
         value: 24.93317917581306
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 25.060580072591037
+        value: 25.06
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 25.060580072591037
+        value: 25.06
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 25.06170905067327
+        value: 25.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 25.24665656136374
+        value: 25.25
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 22.879304077469147
+        value: 22.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 21.346632308674636
+        value: 21.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 25.4918540433925
+        value: 25.49
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -119,25 +119,25 @@ emissionFactors:
         value: 24.93317917581306
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 25.060580072591037
+        value: 25.06
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 25.060580072591037
+        value: 25.06
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 25.06170905067327
+        value: 25.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 25.24665656136374
+        value: 25.25
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 22.879304077469147
+        value: 22.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 21.346632308674636
+        value: 21.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 25.4918540433925
+        value: 25.49
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -115,25 +115,25 @@ emissionFactors:
         value: 645.3016368008209
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 696.9287628648111
+        value: 696.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 666.8102533791609
+        value: 666.81
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 666.427574176914
+        value: 666.43
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 650.3430372661014
+        value: 650.34
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 566.610052489585
+        value: 566.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 534.0443505429737
+        value: 534.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 450.20871208964775
+        value: 450.21
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -143,25 +143,25 @@ emissionFactors:
         value: 645.3016368008209
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 696.9287628648111
+        value: 696.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 666.8102533791609
+        value: 666.81
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 666.427574176914
+        value: 666.43
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 650.3430372661014
+        value: 650.34
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 566.610052489585
+        value: 566.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 534.0443505429737
+        value: 534.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 450.20871208964775
+        value: 450.21
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -38,14 +38,14 @@ emissionFactors:
         value: 475.16042054489543
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 494.2083458391532
+        value: 494.21
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 475.16042054489543
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 494.2083458391532
+        value: 494.21
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -106,25 +106,25 @@ emissionFactors:
         value: 510.8590975293004
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 577.7569712332119
+        value: 577.76
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 559.8796745899491
+        value: 559.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 522.5583778880402
+        value: 522.56
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 488.1195552641504
+        value: 488.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 464.4462818159344
+        value: 464.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 430.88110948199784
+        value: 430.88
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 359.0481155050275
+        value: 359.05
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -134,25 +134,25 @@ emissionFactors:
         value: 510.8590975293004
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 577.7569712332119
+        value: 577.76
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 559.8796745899491
+        value: 559.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 522.5583778880402
+        value: 522.56
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 488.1195552641504
+        value: 488.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 464.4462818159344
+        value: 464.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 430.88110948199784
+        value: 430.88
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 359.0481155050275
+        value: 359.05
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -36,47 +36,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 628.1594797832028
+        value: 628.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 645.7664605872054
+        value: 645.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 616.6702630792016
+        value: 616.67
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 577.049368690909
+        value: 577.05
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 525.9937517147005
+        value: 525.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 467.0447170052315
+        value: 467.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 376.8228331384161
+        value: 376.82
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 628.1594797832028
+        value: 628.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 645.7664605872054
+        value: 645.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 616.6702630792016
+        value: 616.67
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 577.049368690909
+        value: 577.05
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 525.9937517147005
+        value: 525.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 467.0447170052315
+        value: 467.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 376.8228331384161
+        value: 376.82
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/AW.yaml
+++ b/config/zones/AW.yaml
@@ -41,41 +41,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 542.2651502828871
+        value: 542.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 525.1055410544062
+        value: 525.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 551.8304467180093
+        value: 551.83
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 542.2158589660801
+        value: 542.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 519.64376221501
+        value: 519.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 563.2730413231965
+        value: 563.27
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 542.2651502828871
+        value: 542.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 525.1055410544062
+        value: 525.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 551.8304467180093
+        value: 551.83
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 542.2158589660801
+        value: 542.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 519.64376221501
+        value: 519.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 563.2730413231965
+        value: 563.27
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2018 average

--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -75,27 +75,27 @@ emissionFactors:
         value: 641.08
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 49.17843651621915
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 32.88191425524841
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 27.595966193483754
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 38.57083410386509
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 98.81527820902238
+        value: 98.82
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 49.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 32.88
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 27.6
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 38.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 26.647582398683756
+        value: 26.65
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 22.150543574420823
+        value: 22.15
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -119,27 +119,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 49.17843651621915
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 32.88191425524841
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 27.595966193483754
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 38.57083410386509
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 98.81527820902238
+        value: 98.82
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 49.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 32.88
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 27.6
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 38.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 26.647582398683756
+        value: 26.65
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 22.150543574420823
+        value: 22.15
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -161,6 +161,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.3916076049049387
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0009224884688941389
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.6073799077511531
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -221,21 +236,6 @@ fallbackZoneMixes:
         solar: 0.00036411835940856684
         unknown: 0.06393762928373665
         wind: 0.3251014539829839
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.3916076049049387
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0009224884688941389
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.6073799077511531
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -68,25 +68,25 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 702.3969517909702
+        value: 702.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 604.7625170901181
+        value: 604.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 521.8761918519289
+        value: 521.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 550.9712704661262
+        value: 550.97
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.1843058242669
+        value: 520.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 560.8375537943476
+        value: 560.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 660.2158224711999
+        value: 660.22
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -94,25 +94,25 @@ emissionFactors:
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 702.3969517909702
+        value: 702.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 604.7625170901181
+        value: 604.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 521.8761918519289
+        value: 521.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 550.9712704661262
+        value: 550.97
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.1843058242669
+        value: 520.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 560.8375537943476
+        value: 560.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 660.2158224711999
+        value: 660.22
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BD.yaml
+++ b/config/zones/BD.yaml
@@ -50,59 +50,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 530.2603113417732
+        value: 530.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 540.8276546943755
+        value: 540.83
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 541.0548112797912
+        value: 541.05
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.3215044692921
+        value: 545.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.8832631178165
+        value: 539.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 551.6213724695482
+        value: 551.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 557.6569820791016
+        value: 557.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 578.0674353344797
+        value: 578.07
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 604.0258086815977
+        value: 604.03
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 530.2603113417732
+        value: 530.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 540.8276546943755
+        value: 540.83
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 541.0548112797912
+        value: 541.05
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.3215044692921
+        value: 545.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.8832631178165
+        value: 539.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 551.6213724695482
+        value: 551.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 557.6569820791016
+        value: 557.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 578.0674353344797
+        value: 578.07
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 604.0258086815977
+        value: 604.03
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -151,31 +151,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 260.9644998542691
+        value: 260.96
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 212.06001541941782
+        value: 212.06
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 214.2478624177472
+        value: 214.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 224.33222102851894
+        value: 224.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 190.6673883683655
+        value: 190.67
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 198.48178948692149
+        value: 198.48
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 149.9936180905859
+        value: 149.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 170.25586331851073
+        value: 170.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 151.76447171469792
+        value: 151.76
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -209,31 +209,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 260.9644998542691
+        value: 260.96
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 212.06001541941782
+        value: 212.06
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 214.2478624177472
+        value: 214.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 224.33222102851894
+        value: 224.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 190.6673883683655
+        value: 190.67
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 198.48178948692149
+        value: 198.48
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 149.9936180905859
+        value: 149.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 170.25586331851073
+        value: 170.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 151.76447171469792
+        value: 151.76
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BG.yaml
+++ b/config/zones/BG.yaml
@@ -151,31 +151,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 544.2007617626946
+        value: 544.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 529.0258902795842
+        value: 529.03
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 584.0097804341657
+        value: 584.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 473.59772984503525
+        value: 473.6
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 471.77236890987814
+        value: 471.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 414.9478765520519
+        value: 414.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 468.9288088007689
+        value: 468.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 538.0507364115407
+        value: 538.05
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 383.6489900248197
+        value: 383.65
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -209,31 +209,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 544.2007617626946
+        value: 544.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 529.0258902795842
+        value: 529.03
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 584.0097804341657
+        value: 584.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 473.59772984503525
+        value: 473.6
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 471.77236890987814
+        value: 471.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 414.9478765520519
+        value: 414.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 468.9288088007689
+        value: 468.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 538.0507364115407
+        value: 538.05
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 383.6489900248197
+        value: 383.65
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BH.yaml
+++ b/config/zones/BH.yaml
@@ -17,17 +17,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 700.0000000000001
+        value: 700.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 700.0000000000001
+        value: 700.0
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 700.0000000000001
+        value: 700.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 700.0000000000001
+        value: 700.0
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average

--- a/config/zones/BO.yaml
+++ b/config/zones/BO.yaml
@@ -81,47 +81,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 385.72843254185267
+        value: 385.73
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 346.3121890140969
+        value: 346.31
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 314.947960669568
+        value: 314.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 324.4623883482573
+        value: 324.46
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 318.5106507265494
+        value: 318.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 320.16608377735594
+        value: 320.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 349.29204054340426
+        value: 349.29
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 385.72843254185267
+        value: 385.73
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 346.3121890140969
+        value: 346.31
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 314.947960669568
+        value: 314.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 324.4623883482573
+        value: 324.46
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 318.5106507265494
+        value: 318.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 320.16608377735594
+        value: 320.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 349.29204054340426
+        value: 349.29
     unknown:
       _url: https://www.iea.org/fuels-and-technologies/electricity
       source: IEA 2020; assumes 1.3% oil, 96.0% gas, 2.6% biomass

--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -86,25 +86,25 @@ emissionFactors:
         value: 117.88590300129731
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 141.77890033756074
+        value: 141.78
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 113.95400774618936
+        value: 113.95
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 107.06600486251018
+        value: 107.07
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 147.6798495480684
+        value: 147.68
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 170.1762916814213
+        value: 170.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.92446051150914
+        value: 99.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 89.54905754705324
+        value: 89.55
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,25 +114,25 @@ emissionFactors:
         value: 117.88590300129731
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 141.77890033756074
+        value: 141.78
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 113.95400774618936
+        value: 113.95
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 107.06600486251018
+        value: 107.07
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 147.6798495480684
+        value: 147.68
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 170.1762916814213
+        value: 170.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.92446051150914
+        value: 99.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 89.54905754705324
+        value: 89.55
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -86,25 +86,25 @@ emissionFactors:
         value: 154.1014375526151
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 311.88590811668274
+        value: 311.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 114.34766717666737
+        value: 114.35
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 170.93830721066115
+        value: 170.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 173.0053057696738
+        value: 173.01
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.95220293704656
+        value: 183.95
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 106.30333124525116
+        value: 106.3
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.80396686938991
+        value: 107.8
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,25 +114,25 @@ emissionFactors:
         value: 154.1014375526151
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 311.88590811668274
+        value: 311.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 114.34766717666737
+        value: 114.35
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 170.93830721066115
+        value: 170.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 173.0053057696738
+        value: 173.01
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.95220293704656
+        value: 183.95
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 106.30333124525116
+        value: 106.3
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.80396686938991
+        value: 107.8
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -86,25 +86,25 @@ emissionFactors:
         value: 131.55199389943078
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 239.87250674057103
+        value: 239.87
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 176.6990087164326
+        value: 176.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 147.10843475894416
+        value: 147.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 107.22146325720595
+        value: 107.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 156.05240963584453
+        value: 156.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 51.92199860641761
+        value: 51.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 42.99226776354122
+        value: 42.99
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,25 +114,25 @@ emissionFactors:
         value: 131.55199389943078
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 239.87250674057103
+        value: 239.87
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 176.6990087164326
+        value: 176.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 147.10843475894416
+        value: 147.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 107.22146325720595
+        value: 107.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 156.05240963584453
+        value: 156.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 51.92199860641761
+        value: 51.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 42.99226776354122
+        value: 42.99
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -86,25 +86,25 @@ emissionFactors:
         value: 123.20145606017441
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 117.7294377353405
+        value: 117.73
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 274.7149924264138
+        value: 274.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 107.97218824889994
+        value: 107.97
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 278.88045148996014
+        value: 278.88
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 170.35138957175343
+        value: 170.35
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 94.73090770453732
+        value: 94.73
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.64519087553792
+        value: 82.65
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,25 +114,25 @@ emissionFactors:
         value: 123.20145606017441
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 117.7294377353405
+        value: 117.73
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 274.7149924264138
+        value: 274.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 107.97218824889994
+        value: 107.97
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 278.88045148996014
+        value: 278.88
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 170.35138957175343
+        value: 170.35
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 94.73090770453732
+        value: 94.73
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.64519087553792
+        value: 82.65
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/BR.yaml
+++ b/config/zones/BR.yaml
@@ -21,47 +21,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 169.85871579567657
+        value: 169.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 120.71146819902333
+        value: 120.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 119.2401441723357
+        value: 119.24
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 187.3958431777143
+        value: 187.4
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 169.06683671960457
+        value: 169.07
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 91.76805743942437
+        value: 91.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.49103552392339
+        value: 82.49
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 169.85871579567657
+        value: 169.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 120.71146819902333
+        value: 120.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 119.2401441723357
+        value: 119.24
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 187.3958431777143
+        value: 187.4
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 169.06683671960457
+        value: 169.07
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 91.76805743942437
+        value: 91.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.49103552392339
+        value: 82.49
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -51,68 +51,53 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 587.9450054405484
+        value: 587.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 553.550590778098
+        value: 553.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 527.7239838823372
+        value: 527.72
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 526.123425071578
+        value: 526.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 483.5185573691791
+        value: 483.52
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.9396704563736
+        value: 465.94
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 435.78996270310404
+        value: 435.79
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 587.9450054405484
+        value: 587.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 553.550590778098
+        value: 553.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 527.7239838823372
+        value: 527.72
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 526.123425071578
+        value: 526.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 483.5185573691791
+        value: 483.52
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.9396704563736
+        value: 465.94
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 435.78996270310404
+        value: 435.79
     unknown:
       source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
         plant
       value: 655
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 4.664314467495561e-10
-        biomass: 0.006307823217849085
-        coal: 0.3284617665436456
-        gas: 0.5526737870409065
-        geothermal: 1.230212940801954e-07
-        hydro: 0.025846428260547016
-        hydro discharge: 2.014983849958082e-07
-        nuclear: 1.1785556580744407e-05
-        oil: 0.00027644412342808013
-        solar: 0.004358911364656726
-        unknown: 0.02698973068005254
-        wind: 0.05507297525447451
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -143,6 +128,21 @@ fallbackZoneMixes:
         solar: 0.0001577554454042984
         unknown: 0.028485575923070713
         wind: 0.04859175599414431
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 4.664314467495561e-10
+        biomass: 0.006307823217849085
+        coal: 0.3284617665436456
+        gas: 0.5526737870409065
+        geothermal: 1.230212940801954e-07
+        hydro: 0.025846428260547016
+        hydro discharge: 2.014983849958082e-07
+        nuclear: 1.1785556580744407e-05
+        oil: 0.00027644412342808013
+        solar: 0.004358911364656726
+        unknown: 0.02698973068005254
+        wind: 0.05507297525447451
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:

--- a/config/zones/CA-BC.yaml
+++ b/config/zones/CA-BC.yaml
@@ -22,11 +22,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 71.88523615564627
+        value: 71.89
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 71.88523615564627
+        value: 71.89
     unknown:
       - datetime: '2019-01-01'
         source: assumes 87% hydro, 5% biomass, 4% gas, 2% wind and 2% from various sources

--- a/config/zones/CA-NB.yaml
+++ b/config/zones/CA-NB.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 171.68036145728934
+        value: 171.68
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 152.62689904044262
+        value: 152.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 153.657687279815
+        value: 153.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 145.25514504162197
+        value: 145.26
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 145.5431283624887
+        value: 145.54
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 144.36508504138442
+        value: 144.37
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 158.27703086675336
+        value: 158.28
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 171.68036145728934
+        value: 171.68
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 152.62689904044262
+        value: 152.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 153.657687279815
+        value: 153.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 145.25514504162197
+        value: 145.26
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 145.5431283624887
+        value: 145.54
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 144.36508504138442
+        value: 144.37
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 158.27703086675336
+        value: 158.28
     unknown:
       - datetime: '2019-01-01'
         source: Government of Canada 2019; assumes 37.54% nuclear, 22.41% hydro, 14.53%
@@ -77,6 +77,21 @@ emissionFactors:
         value: 211.9
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.005308708858735968
+        coal: 0.0017369039827391606
+        gas: 0.0006865019615367694
+        geothermal: 3.2320241195255577e-09
+        hydro: 0.20794482038652326
+        hydro discharge: 0.0
+        nuclear: 0.000607898488545084
+        oil: 2.9734621899635132e-08
+        solar: 1.3597771875667927e-05
+        unknown: 0.7719997802378735
+        wind: 0.011700468999924952
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -107,21 +122,6 @@ fallbackZoneMixes:
         solar: 2.8647917168144602e-05
         unknown: 0.6776669776700435
         wind: 0.016262356364234988
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.005308708858735968
-        coal: 0.0017369039827391606
-        gas: 0.0006865019615367694
-        geothermal: 3.2320241195255577e-09
-        hydro: 0.20794482038652326
-        hydro discharge: 0.0
-        nuclear: 0.000607898488545084
-        oil: 2.9734621899635132e-08
-        solar: 1.3597771875667927e-05
-        unknown: 0.7719997802378735
-        wind: 0.011700468999924952
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:

--- a/config/zones/CA-NS.yaml
+++ b/config/zones/CA-NS.yaml
@@ -49,29 +49,29 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 426.8445977974951
+        value: 426.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 518.2793069399034
+        value: 518.28
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 479.74118532013614
+        value: 479.74
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 443.44608891751625
+        value: 443.45
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 426.8445977974951
+        value: 426.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 518.2793069399034
+        value: 518.28
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 479.74118532013614
+        value: 479.74
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 443.44608891751625
+        value: 443.45
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -103,25 +103,25 @@ emissionFactors:
         value: 53.48323094170299
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 56.374046770749764
+        value: 56.37
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.858878142689406
+        value: 43.86
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 43.207348033428495
+        value: 43.21
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 44.34214561326827
+        value: 44.34
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 53.60686129515445
+        value: 53.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 63.011640452059524
+        value: 63.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 76.4223537785992
+        value: 76.42
     gas:
       datetime: '2008-01-01'
       source: "Mallia, E., Lewis, G. \"Life cycle greenhouse gas emissions of electricity\
@@ -143,25 +143,25 @@ emissionFactors:
         value: 53.48323094170299
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 56.374046770749764
+        value: 56.37
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.858878142689406
+        value: 43.86
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 43.207348033428495
+        value: 43.21
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 44.34214561326827
+        value: 44.34
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 53.60686129515445
+        value: 53.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 63.011640452059524
+        value: 63.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 76.4223537785992
+        value: 76.42
     nuclear:
       datetime: '2008-01-01'
       source: "Mallia, E., Lewis, G. \"Life cycle greenhouse gas emissions of electricity\

--- a/config/zones/CA-PE.yaml
+++ b/config/zones/CA-PE.yaml
@@ -48,47 +48,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 58.70083417886525
+        value: 58.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 92.5356737820939
+        value: 92.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 95.70019308999947
+        value: 95.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 88.42069746818031
+        value: 88.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 95.47925100377687
+        value: 95.48
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.97283507720316
+        value: 99.97
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 118.15829851395863
+        value: 118.16
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 58.70083417886525
+        value: 58.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 92.5356737820939
+        value: 92.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 95.70019308999947
+        value: 95.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 88.42069746818031
+        value: 88.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 95.47925100377687
+        value: 95.48
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.97283507720316
+        value: 99.97
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 118.15829851395863
+        value: 118.16
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/CA-QC.yaml
+++ b/config/zones/CA-QC.yaml
@@ -78,25 +78,25 @@ emissionFactors:
         value: 28.295837431080226
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 28.38890475047584
+        value: 28.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 28.321985184948698
+        value: 28.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 28.27868286988289
+        value: 28.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 28.30219708931248
+        value: 28.3
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 28.39452007818742
+        value: 28.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 28.219283614282684
+        value: 28.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 30.51463527746081
+        value: 30.51
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -106,25 +106,25 @@ emissionFactors:
         value: 28.295837431080226
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 28.38890475047584
+        value: 28.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 28.321985184948698
+        value: 28.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 28.27868286988289
+        value: 28.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 28.30219708931248
+        value: 28.3
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 28.39452007818742
+        value: 28.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 28.219283614282684
+        value: 28.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 30.51463527746081
+        value: 30.51
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -44,47 +44,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 526.9535008317545
+        value: 526.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 526.8939002764918
+        value: 526.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 526.6022022572881
+        value: 526.6
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 526.5455735854018
+        value: 526.55
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 526.5023178171368
+        value: 526.5
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 525.3462461543147
+        value: 525.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 517.2211061441782
+        value: 517.22
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 526.9535008317545
+        value: 526.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 526.8939002764918
+        value: 526.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 526.6022022572881
+        value: 526.6
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 526.5455735854018
+        value: 526.55
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 526.5023178171368
+        value: 526.5
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 525.3462461543147
+        value: 525.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 517.2211061441782
+        value: 517.22
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/CA-YT.yaml
+++ b/config/zones/CA-YT.yaml
@@ -47,47 +47,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 45.98924774605369
+        value: 45.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 80.13342647211215
+        value: 80.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 127.92589593577578
+        value: 127.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 106.74640307595777
+        value: 106.75
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 71.69917597538533
+        value: 71.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 78.14585748925272
+        value: 78.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 83.54717061868135
+        value: 83.55
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 45.98924774605369
+        value: 45.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 80.13342647211215
+        value: 80.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 127.92589593577578
+        value: 127.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 106.74640307595777
+        value: 106.75
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 71.69917597538533
+        value: 71.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 78.14585748925272
+        value: 78.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 83.54717061868135
+        value: 83.55
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -111,25 +111,25 @@ emissionFactors:
         value: 188.08129054877446
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 199.28812434614267
+        value: 199.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 176.34052430698068
+        value: 176.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 129.31133833196046
+        value: 129.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 107.21791932402232
+        value: 107.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 90.75076294610514
+        value: 90.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 186.33058919952646
+        value: 186.33
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 73.85682575756005
+        value: 73.86
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -151,25 +151,25 @@ emissionFactors:
         value: 188.08129054877446
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 199.28812434614267
+        value: 199.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 176.34052430698068
+        value: 176.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 129.31133833196046
+        value: 129.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 107.21791932402232
+        value: 107.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 90.75076294610514
+        value: 90.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 186.33058919952646
+        value: 186.33
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 73.85682575756005
+        value: 73.86
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -116,59 +116,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 358.8632549221904
+        value: 358.86
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 474.6347539562896
+        value: 474.63
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 431.7398123208508
+        value: 431.74
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 410.3034669087491
+        value: 410.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 415.308210929995
+        value: 415.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 399.215753052016
+        value: 399.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 405.2281219448687
+        value: 405.23
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 321.66374641829935
+        value: 321.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 272.2606459691407
+        value: 272.26
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 358.8632549221904
+        value: 358.86
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 474.6347539562896
+        value: 474.63
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 431.7398123208508
+        value: 431.74
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 410.3034669087491
+        value: 410.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 415.308210929995
+        value: 415.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 399.215753052016
+        value: 399.22
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 405.2281219448687
+        value: 405.23
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 321.66374641829935
+        value: 321.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 272.2606459691407
+        value: 272.26
     unknown:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average.

--- a/config/zones/CO.yaml
+++ b/config/zones/CO.yaml
@@ -58,59 +58,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 211.45496643198538
+        value: 211.45
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 189.0436058266023
+        value: 189.04
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 97.92822808199158
+        value: 97.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 120.17850026737783
+        value: 120.18
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 157.65561933216514
+        value: 157.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 195.53089639576385
+        value: 195.53
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 126.0477526059731
+        value: 126.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 112.47394788638053
+        value: 112.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 148.27612938665095
+        value: 148.28
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 211.45496643198538
+        value: 211.45
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 189.0436058266023
+        value: 189.04
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 97.92822808199158
+        value: 97.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 120.17850026737783
+        value: 120.18
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 157.65561933216514
+        value: 157.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 195.53089639576385
+        value: 195.53
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 126.0477526059731
+        value: 126.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 112.47394788638053
+        value: 112.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 148.27612938665095
+        value: 148.28
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/CR.yaml
+++ b/config/zones/CR.yaml
@@ -98,25 +98,25 @@ emissionFactors:
         value: 40.897253420611605
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 44.575593024793704
+        value: 44.58
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 53.007541524591474
+        value: 53.01
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 54.62804511046182
+        value: 54.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 51.89165724729522
+        value: 51.89
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 40.2651502428549
+        value: 40.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 47.75726861687618
+        value: 47.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 70.45303604901224
+        value: 70.45
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -126,25 +126,25 @@ emissionFactors:
         value: 40.897253420611605
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 44.575593024793704
+        value: 44.58
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 53.007541524591474
+        value: 53.01
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 54.62804511046182
+        value: 54.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 51.89165724729522
+        value: 51.89
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 40.2651502428549
+        value: 40.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 47.75726861687618
+        value: 47.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 70.45303604901224
+        value: 70.45
     unknown:
       _comment: Source https://www.grupoice.com/wps/wcm/connect/579dfc1f-5156-41e0-807d-d6808f65d718/Fasciculo_Electricidad_2020_ingl%C3%A9s_compressed.pdf?MOD=AJPERES&CVID=m.pGzcp
       source: assumes 58% thermal (coal, gas, or oil), 42% solar and biomass

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -112,25 +112,25 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 897.0374918125898
+        value: 897.04
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 890.5854965969127
+        value: 890.59
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 864.8511314069107
+        value: 864.85
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 835.5984908199194
+        value: 835.6
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 820.0666560912442
+        value: 820.07
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 805.6331243600923
+        value: 805.63
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 765.7573032980683
+        value: 765.76
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,25 +162,25 @@ emissionFactors:
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 897.0374918125898
+        value: 897.04
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 890.5854965969127
+        value: 890.59
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 864.8511314069107
+        value: 864.85
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 835.5984908199194
+        value: 835.6
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 820.0666560912442
+        value: 820.07
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 805.6331243600923
+        value: 805.63
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 765.7573032980683
+        value: 765.76
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -146,31 +146,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 616.2558202860275
+        value: 616.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 637.3257376666186
+        value: 637.33
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 591.4718398471557
+        value: 591.47
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 569.710677203193
+        value: 569.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 533.7026145628882
+        value: 533.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 478.9115572678275
+        value: 478.91
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 523.6334519553443
+        value: 523.63
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 533.2952498403307
+        value: 533.3
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 468.91770123296044
+        value: 468.92
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -204,31 +204,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 616.2558202860275
+        value: 616.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 637.3257376666186
+        value: 637.33
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 591.4718398471557
+        value: 591.47
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 569.710677203193
+        value: 569.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 533.7026145628882
+        value: 533.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 478.9115572678275
+        value: 478.91
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 523.6334519553443
+        value: 523.63
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 533.2952498403307
+        value: 533.3
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 468.91770123296044
+        value: 468.92
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -173,31 +173,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 543.3303309539009
+        value: 543.33
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 529.8497871948806
+        value: 529.85
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 498.9865130377661
+        value: 498.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 467.75997052824994
+        value: 467.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 383.80229675743203
+        value: 383.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 333.518281184316
+        value: 333.52
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 392.1690114770364
+        value: 392.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 415.84200523690146
+        value: 415.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 325.2362129410304
+        value: 325.24
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -231,31 +231,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 543.3303309539009
+        value: 543.33
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 529.8497871948806
+        value: 529.85
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 498.9865130377661
+        value: 498.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 467.75997052824994
+        value: 467.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 383.80229675743203
+        value: 383.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 333.518281184316
+        value: 333.52
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 392.1690114770364
+        value: 392.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 415.84200523690146
+        value: 415.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 325.2362129410304
+        value: 325.24
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DK-BHM.yaml
+++ b/config/zones/DK-BHM.yaml
@@ -74,27 +74,27 @@ emissionFactors:
         value: 641.08
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 68.45954875771356
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 70.97165487996881
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 51.25102822733711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 67.1097672793614
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 59.748829860881514
+        value: 59.75
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 68.46
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 70.97
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 51.25
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 67.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 70.36032386307718
+        value: 70.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 56.10519457623342
+        value: 56.11
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -126,27 +126,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 68.45954875771356
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 70.97165487996881
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 51.25102822733711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 67.1097672793614
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 59.748829860881514
+        value: 59.75
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 68.46
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 70.97
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 51.25
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 67.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 70.36032386307718
+        value: 70.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 56.10519457623342
+        value: 56.11
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -172,6 +172,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.15661168716629678
+        coal: 0.00331716485371506
+        gas: 0.0016947962005256904
+        geothermal: 0.0
+        hydro: 0.1213849962993853
+        hydro discharge: 0.00011383273255180241
+        nuclear: 0.11550117235524167
+        oil: 0.00017066502738564176
+        solar: 0.09543327709934693
+        unknown: 0.029608490643962444
+        wind: 0.4761488688334596
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -232,21 +247,6 @@ fallbackZoneMixes:
         solar: 0.08727843387655994
         unknown: 0.052260493816852584
         wind: 0.45079278422964475
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.15661168716629678
-        coal: 0.00331716485371506
-        gas: 0.0016947962005256904
-        geothermal: 0.0
-        hydro: 0.1213849962993853
-        hydro discharge: 0.00011383273255180241
-        nuclear: 0.11550117235524167
-        oil: 0.00017066502738564176
-        solar: 0.09543327709934693
-        unknown: 0.029608490643962444
-        wind: 0.4761488688334596
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -126,31 +126,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 252.72688091540635
+        value: 252.73
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 317.1933940717397
+        value: 317.19
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 233.44601795016132
+        value: 233.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 243.91033183838866
+        value: 243.91
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 215.44437381272667
+        value: 215.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 168.13359044458542
+        value: 168.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 212.73502814014842
+        value: 212.74
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 198.0107113608226
+        value: 198.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 146.07112269955996
+        value: 146.07
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -184,31 +184,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 252.72688091540635
+        value: 252.73
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 317.1933940717397
+        value: 317.19
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 233.44601795016132
+        value: 233.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 243.91033183838866
+        value: 243.91
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 215.44437381272667
+        value: 215.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 168.13359044458542
+        value: 168.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 212.73502814014842
+        value: 212.74
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 198.0107113608226
+        value: 198.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 146.07112269955996
+        value: 146.07
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -126,31 +126,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 275.7915517129539
+        value: 275.79
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 367.8073774129317
+        value: 367.81
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 255.586850199721
+        value: 255.59
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 292.1158463911062
+        value: 292.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 216.83931511879356
+        value: 216.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 178.58223410704477
+        value: 178.58
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 214.17194749477332
+        value: 214.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 165.52261533187215
+        value: 165.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 154.11536842274396
+        value: 154.12
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -184,31 +184,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 275.7915517129539
+        value: 275.79
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 367.8073774129317
+        value: 367.81
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 255.586850199721
+        value: 255.59
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 292.1158463911062
+        value: 292.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 216.83931511879356
+        value: 216.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 178.58223410704477
+        value: 178.58
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 214.17194749477332
+        value: 214.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 165.52261533187215
+        value: 165.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 154.11536842274396
+        value: 154.12
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DK.yaml
+++ b/config/zones/DK.yaml
@@ -83,27 +83,27 @@ emissionFactors:
         value: 641.08
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 261.3780360297862
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 214.96428192503367
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 170.4465596912881
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 212.24846956917958
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 237.98267024118508
+        value: 237.98
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 261.38
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 214.96
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 170.45
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 212.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 185.0646756439038
+        value: 185.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 148.55417985340475
+        value: 148.55
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -135,27 +135,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 261.3780360297862
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 214.96428192503367
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 170.4465596912881
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 212.24846956917958
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 237.98267024118508
+        value: 237.98
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 261.38
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 214.96
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 170.45
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 212.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 185.0646756439038
+        value: 185.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 148.55417985340475
+        value: 148.55
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -181,6 +181,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.13592492222233807
+        coal: 0.14862982190567306
+        gas: 0.05243304314606192
+        geothermal: 2.5875053975861645e-05
+        hydro: 0.17118696548583506
+        hydro discharge: 0.0007676193340449683
+        nuclear: 0.05942030791063363
+        oil: 0.018623963649979692
+        solar: 0.028327849551991077
+        unknown: 0.016247130929536672
+        wind: 0.3684124799041742
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -241,21 +256,6 @@ fallbackZoneMixes:
         solar: 0.04169909263375615
         unknown: 0.018244783224464246
         wind: 0.36318754620577526
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.13592492222233807
-        coal: 0.14862982190567306
-        gas: 0.05243304314606192
-        geothermal: 2.5875053975861645e-05
-        hydro: 0.17118696548583506
-        hydro discharge: 0.0007676193340449683
-        nuclear: 0.05942030791063363
-        oil: 0.018623963649979692
-        solar: 0.028327849551991077
-        unknown: 0.016247130929536672
-        wind: 0.3684124799041742
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/DO.yaml
+++ b/config/zones/DO.yaml
@@ -54,47 +54,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 501.48778269197436
+        value: 501.49
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 510.06702078555355
+        value: 510.07
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.1447573796767
+        value: 539.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 579.4674295058629
+        value: 579.47
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 543.3047882482156
+        value: 543.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 545.1396707528042
+        value: 545.14
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 579.8937385632154
+        value: 579.89
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 501.48778269197436
+        value: 501.49
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 510.06702078555355
+        value: 510.07
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.1447573796767
+        value: 539.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 579.4674295058629
+        value: 579.47
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 543.3047882482156
+        value: 543.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 545.1396707528042
+        value: 545.14
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 579.8937385632154
+        value: 579.89
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -150,31 +150,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 553.9195470184378
+        value: 553.92
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 639.6439540507571
+        value: 639.64
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 685.0820011420446
+        value: 685.08
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 653.0466608853077
+        value: 653.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 465.25817237047437
+        value: 465.26
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 306.96041095085525
+        value: 306.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 386.2463946859338
+        value: 386.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 429.2448798365503
+        value: 429.24
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 280.15076435096387
+        value: 280.15
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -206,31 +206,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 553.9195470184378
+        value: 553.92
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 639.6439540507571
+        value: 639.64
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 685.0820011420446
+        value: 685.08
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 653.0466608853077
+        value: 653.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 465.25817237047437
+        value: 465.26
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 306.96041095085525
+        value: 306.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 386.2463946859338
+        value: 386.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 429.2448798365503
+        value: 429.24
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 280.15076435096387
+        value: 280.15
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -20,17 +20,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 649.2911372065031
+        value: 649.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 649.8156432979637
+        value: 649.82
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 649.2911372065031
+        value: 649.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 649.8156432979637
+        value: 649.82
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average

--- a/config/zones/ES-CN-FVLZ.yaml
+++ b/config/zones/ES-CN-FVLZ.yaml
@@ -80,22 +80,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 1015.7777206410498
+        value: 1015.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1009.5156292338376
+        value: 1009.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 999.6966693688917
+        value: 999.7
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 959.2807261794248
+        value: 959.28
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 992.8717366383511
+        value: 992.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1014.0134917008232
+        value: 1014.01
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -123,22 +123,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 1015.7777206410498
+        value: 1015.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1009.5156292338376
+        value: 1009.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 999.6966693688917
+        value: 999.7
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 959.2807261794248
+        value: 959.28
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 992.8717366383511
+        value: 992.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1014.0134917008232
+        value: 1014.01
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -80,22 +80,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 766.4584520478932
+        value: 766.46
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 941.7314573402197
+        value: 941.73
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 930.6660986693346
+        value: 930.67
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 885.8839438703468
+        value: 885.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 889.1301716277707
+        value: 889.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 900.9572090467029
+        value: 900.96
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -123,22 +123,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 766.4584520478932
+        value: 766.46
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 941.7314573402197
+        value: 941.73
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 930.6660986693346
+        value: 930.67
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 885.8839438703468
+        value: 885.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 889.1301716277707
+        value: 889.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 900.9572090467029
+        value: 900.96
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -84,22 +84,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 141.68045687968112
+        value: 141.68
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 178.09586340661477
+        value: 178.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 226.55943032695134
+        value: 226.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 198.35651454201545
+        value: 198.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 202.40051932348086
+        value: 202.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 262.4488875993056
+        value: 262.45
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -127,22 +127,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 141.68045687968112
+        value: 141.68
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 178.09586340661477
+        value: 178.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 226.55943032695134
+        value: 226.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 198.35651454201545
+        value: 198.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 202.40051932348086
+        value: 202.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 262.4488875993056
+        value: 262.45
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -180,6 +180,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.05031198057583127
+        nuclear: 0.0
+        oil: 0.40438669737212996
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.5453101862158201
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -225,21 +240,6 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.48829033452562287
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.05031198057583127
-        nuclear: 0.0
-        oil: 0.40438669737212996
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.5453101862158201
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -82,22 +82,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1124.9000000000005
+        value: 1124.9
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
         value: 1169.95
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1087.1082461849642
+        value: 1087.11
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -125,22 +125,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1124.9000000000005
+        value: 1124.9
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 1124.8999999999999
+        value: 1124.9
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
         value: 1169.95
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1087.1082461849642
+        value: 1087.11
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -80,22 +80,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 998.1021977802769
+        value: 998.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1001.315602634187
+        value: 1001.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 1010.1146208172005
+        value: 1010.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 1013.7137811496762
+        value: 1013.71
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 1078.8980830879166
+        value: 1078.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1088.1615138254667
+        value: 1088.16
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -123,22 +123,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 998.1021977802769
+        value: 998.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 1001.315602634187
+        value: 1001.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 1010.1146208172005
+        value: 1010.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 1013.7137811496762
+        value: 1013.71
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 1078.8980830879166
+        value: 1078.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 1088.1615138254667
+        value: 1088.16
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -80,22 +80,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 778.0492264861842
+        value: 778.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 910.5392098252222
+        value: 910.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 897.1185118543032
+        value: 897.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 887.362828644924
+        value: 887.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 945.7598465777598
+        value: 945.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 949.4407768019356
+        value: 949.44
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -123,22 +123,22 @@ emissionFactors:
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 778.0492264861842
+        value: 778.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 910.5392098252222
+        value: 910.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 897.1185118543032
+        value: 897.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 887.362828644924
+        value: 887.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 945.7598465777598
+        value: 945.76
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 949.4407768019356
+        value: 949.44
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-FO.yaml
+++ b/config/zones/ES-IB-FO.yaml
@@ -57,24 +57,24 @@ emissionFactors:
         value: 925.95
   lifecycle:
     battery discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 703.9975436444669
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 463.10057449378775
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 561.721170093285
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 597.4622993852441
+        value: 597.46
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 704.0
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 463.1
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 561.72
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 608.7738367058605
+        value: 608.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 425.614608645698
+        value: 425.61
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -100,24 +100,24 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 703.9975436444669
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 463.10057449378775
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 561.721170093285
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 597.4622993852441
+        value: 597.46
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 704.0
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 463.1
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 561.72
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 608.7738367058605
+        value: 608.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 425.614608645698
+        value: 425.61
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -140,6 +140,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.047111164759745146
+        coal: 0.3288706770936619
+        gas: 0.4558289719867909
+        geothermal: 0.0
+        hydro: 0.022658883782688544
+        hydro discharge: 0.0003944611617420095
+        nuclear: 0.03896543399349894
+        oil: 0.0017869306179460432
+        solar: 0.06963640596304567
+        unknown: 0.00083203283296402
+        wind: 0.033432200101740805
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -185,21 +200,6 @@ fallbackZoneMixes:
         solar: 0.07134415624805623
         unknown: 0.0005566161565415158
         wind: 0.029363176890700688
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.047111164759745146
-        coal: 0.3288706770936619
-        gas: 0.4558289719867909
-        geothermal: 0.0
-        hydro: 0.022658883782688544
-        hydro discharge: 0.0003944611617420095
-        nuclear: 0.03896543399349894
-        oil: 0.0017869306179460432
-        solar: 0.06963640596304567
-        unknown: 0.00083203283296402
-        wind: 0.033432200101740805
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -72,27 +72,27 @@ emissionFactors:
         value: 925.95
   lifecycle:
     battery discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 591.8676726992077
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 429.8886578189487
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 432.3387935948347
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 508.9634049340539
+        value: 508.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.2519175808752
+        value: 545.25
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 591.87
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 429.89
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 432.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 484.677778504577
+        value: 484.68
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 425.56897292771436
+        value: 425.57
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -130,27 +130,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 591.8676726992077
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 429.8886578189487
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 432.3387935948347
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 508.9634049340539
+        value: 508.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.2519175808752
+        value: 545.25
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 591.87
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 429.89
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 432.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 484.677778504577
+        value: 484.68
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 425.56897292771436
+        value: 425.57
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -173,6 +173,36 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.9804187807295244
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0006599582731124307
+        solar: 0.01887786648077494
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0112917258329075
+        coal: 0.08157607065119638
+        gas: 0.8807455679404854
+        geothermal: 0.0
+        hydro: 0.005548580564484378
+        hydro discharge: 0.00011696767994553189
+        nuclear: 0.0096008616487973
+        oil: 0.0004104775292249344
+        solar: 0.0028405159451156603
+        unknown: 0.00022116939787927693
+        wind: 0.007644272356256877
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -218,36 +248,6 @@ fallbackZoneMixes:
         solar: 0.04526841911933494
         unknown: 0.0008968091257801603
         wind: 0.042227322659733675
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.9804187807295244
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0006599582731124307
-        solar: 0.01887786648077494
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0112917258329075
-        coal: 0.08157607065119638
-        gas: 0.8807455679404854
-        geothermal: 0.0
-        hydro: 0.005548580564484378
-        hydro discharge: 0.00011696767994553189
-        nuclear: 0.0096008616487973
-        oil: 0.0004104775292249344
-        solar: 0.0028405159451156603
-        unknown: 0.00022116939787927693
-        wind: 0.007644272356256877
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -65,27 +65,27 @@ emissionFactors:
         value: 925.95
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 780.9429728718986
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 611.1503725830114
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 414.46343709236066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 427.6560400242705
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 545.1957389380628
+        value: 545.2
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 780.94
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 611.15
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 414.46
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 427.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 480.5088484589036
+        value: 480.51
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 398.8448437749552
+        value: 398.84
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -111,27 +111,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 780.9429728718986
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 611.1503725830114
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 414.46343709236066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 427.6560400242705
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 545.1957389380628
+        value: 545.2
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 780.94
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 611.15
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 414.46
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 427.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 480.5088484589036
+        value: 480.51
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 398.8448437749552
+        value: 398.84
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -154,6 +154,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.07012595966354988
+        coal: 0.13707874124524647
+        gas: 0.7393269371565881
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.052246772607011174
+        unknown: 0.0012160741241621646
+        wind: 0.0
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -214,21 +229,6 @@ fallbackZoneMixes:
         solar: 0.05181717041974183
         unknown: 0.0009162298814908619
         wind: 0.04222276306085863
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.07012595966354988
-        coal: 0.13707874124524647
-        gas: 0.7393269371565881
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.052246772607011174
-        unknown: 0.0012160741241621646
-        wind: 0.0
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -78,27 +78,27 @@ emissionFactors:
         value: 838.759
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 480.5564919202425
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 492.84584468723733
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 462.8194506142758
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 463.3210493263293
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 593.1196294571755
+        value: 593.12
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 480.56
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 492.85
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 462.82
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 463.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 515.5183528185977
+        value: 515.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 682.2014936823517
+        value: 682.2
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -124,27 +124,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 480.5564919202425
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 492.84584468723733
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 462.8194506142758
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 463.3210493263293
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 593.1196294571755
+        value: 593.12
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 480.56
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 492.85
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 462.82
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 463.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 515.5183528185977
+        value: 515.52
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 682.2014936823517
+        value: 682.2
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -179,6 +179,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.7715803953098455
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.17087304568851502
+        solar: 0.0450956905349396
+        unknown: 0.0
+        wind: 0.01241542581698037
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -239,21 +254,6 @@ fallbackZoneMixes:
         solar: 0.0502591196235665
         unknown: 0.00030515264607352844
         wind: 0.02617531074764838
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.7715803953098455
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.17087304568851502
-        solar: 0.0450956905349396
-        unknown: 0.0
-        wind: 0.01241542581698037
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -32,17 +32,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 618.5411566636506
+        value: 618.54
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 621.8026312786602
+        value: 621.8
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 618.5411566636506
+        value: 618.54
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 621.8026312786602
+        value: 621.8
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -168,31 +168,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 271.55212578465364
+        value: 271.55
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 206.49010227821412
+        value: 206.49
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 258.88944489255925
+        value: 258.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 200.08531891717237
+        value: 200.09
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 177.96738069406254
+        value: 177.97
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 151.01645054653477
+        value: 151.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 133.84894982551702
+        value: 133.85
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 183.80376401953686
+        value: 183.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 109.30246280965538
+        value: 109.3
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -226,31 +226,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 271.55212578465364
+        value: 271.55
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 206.49010227821412
+        value: 206.49
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 258.88944489255925
+        value: 258.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 200.08531891717237
+        value: 200.09
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 177.96738069406254
+        value: 177.97
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 151.01645054653477
+        value: 151.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 133.84894982551702
+        value: 133.85
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 183.80376401953686
+        value: 183.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 109.30246280965538
+        value: 109.3
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -159,31 +159,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 195.13897351925795
+        value: 195.14
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 225.2242241887156
+        value: 225.22
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 205.28691960254065
+        value: 205.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 221.38121376409646
+        value: 221.38
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 190.48359255611226
+        value: 190.48
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 137.13743333907317
+        value: 137.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 169.4855936061978
+        value: 169.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 132.6910926053916
+        value: 132.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 85.13608245616663
+        value: 85.14
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -217,31 +217,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 195.13897351925795
+        value: 195.14
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 225.2242241887156
+        value: 225.22
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 205.28691960254065
+        value: 205.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 221.38121376409646
+        value: 221.38
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 190.48359255611226
+        value: 190.48
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 137.13743333907317
+        value: 137.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 169.4855936061978
+        value: 169.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 132.6910926053916
+        value: 132.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 85.13608245616663
+        value: 85.14
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-MI.yaml
+++ b/config/zones/FO-MI.yaml
@@ -59,10 +59,10 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 450.88422830293024
+        value: 450.88
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 595.9331820481025
+        value: 595.93
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -95,10 +95,10 @@ emissionFactors:
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 450.88422830293024
+        value: 450.88
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 595.9331820481025
+        value: 595.93
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-SI.yaml
+++ b/config/zones/FO-SI.yaml
@@ -54,10 +54,10 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 445.25908039651796
+        value: 445.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 522.4273022697698
+        value: 522.43
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -90,10 +90,10 @@ emissionFactors:
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 445.25908039651796
+        value: 445.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 522.4273022697698
+        value: 522.43
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO.yaml
+++ b/config/zones/FO.yaml
@@ -106,10 +106,10 @@ emissionFactors:
         value: 408.8110193788959
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 197.7964444252265
+        value: 197.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 590.0821568739233
+        value: 590.08
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -158,10 +158,10 @@ emissionFactors:
         value: 408.8110193788959
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 197.7964444252265
+        value: 197.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 590.0821568739233
+        value: 590.08
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -57,28 +57,28 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 289.457498800209
+        value: 289.46
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 322.1869897532519
+        value: 322.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 330.98140644747156
+        value: 330.98
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 374.5865554976473
+        value: 374.59
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 333.19757898971324
+        value: 333.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 350.30460297425816
+        value: 350.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 483.9926751337628
+        value: 483.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 433.19335259842944
+        value: 433.19
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -112,28 +112,28 @@ emissionFactors:
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 289.457498800209
+        value: 289.46
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 322.1869897532519
+        value: 322.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 330.98140644747156
+        value: 330.98
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 374.5865554976473
+        value: 374.59
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 333.19757898971324
+        value: 333.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 350.30460297425816
+        value: 350.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 483.9926751337628
+        value: 483.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 433.19335259842944
+        value: 433.19
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -174,31 +174,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 40.41525226016582
+        value: 40.42
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 57.09861460512114
+        value: 57.1
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 65.51779160614906
+        value: 65.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 44.303006108819005
+        value: 44.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 45.31120604524704
+        value: 45.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 45.43372831948587
+        value: 45.43
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 50.8630843693428
+        value: 50.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 83.04246210626764
+        value: 83.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 43.68594370851051
+        value: 43.69
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -232,31 +232,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 40.41525226016582
+        value: 40.42
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 57.09861460512114
+        value: 57.1
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 65.51779160614906
+        value: 65.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 44.303006108819005
+        value: 44.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 45.31120604524704
+        value: 45.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 45.43372831948587
+        value: 45.43
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 50.8630843693428
+        value: 50.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 83.04246210626764
+        value: 83.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 43.68594370851051
+        value: 43.69
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GB-NIR.yaml
+++ b/config/zones/GB-NIR.yaml
@@ -89,25 +89,25 @@ emissionFactors:
         value: 495.18349403296713
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 417.4403643893454
+        value: 417.44
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 373.85468710549986
+        value: 373.85
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 337.1255140627922
+        value: 337.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 328.6298163821583
+        value: 328.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.7454633202924
+        value: 363.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 346.88755077007534
+        value: 346.89
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 285.65635291079457
+        value: 285.66
     gas:
       - datetime: '2023-01-01'
         source: EU-ETS, ENTSO-E 2023; IPCC 2014
@@ -125,25 +125,25 @@ emissionFactors:
         value: 495.18349403296713
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 417.4403643893454
+        value: 417.44
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 373.85468710549986
+        value: 373.85
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 337.1255140627922
+        value: 337.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 328.6298163821583
+        value: 328.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.7454633202924
+        value: 363.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 346.88755077007534
+        value: 346.89
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 285.65635291079457
+        value: 285.66
     oil:
       - datetime: '2023-01-01'
         source: EU-ETS, ENTSO-E 2023; IPCC 2014

--- a/config/zones/GB-ORK.yaml
+++ b/config/zones/GB-ORK.yaml
@@ -42,49 +42,49 @@ emissionFactors:
         value: 460.40202785294656
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 25.79423249807741
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 90.78428883464187
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 50.35587937728895
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 92.41271905047368
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 14.169999999999998
+        value: 14.17
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 25.79
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 90.78
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 50.36
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 92.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 68.11679972482845
+        value: 68.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.6419466049486
+        value: 82.64
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 25.79423249807741
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 90.78428883464187
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 50.35587937728895
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 92.41271905047368
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 14.169999999999998
+        value: 14.17
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 25.79
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 90.78
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 50.36
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 92.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 68.11679972482845
+        value: 68.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 82.6419466049486
+        value: 82.64
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -100,6 +100,21 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 1.0
+        wind: 0.0
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -160,21 +175,6 @@ fallbackZoneMixes:
         solar: 0.012616142536719025
         unknown: 0.7053744676904489
         wind: 0.04136317136250298
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 1.0
-        wind: 0.0
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -127,31 +127,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 330.2628973155362
+        value: 330.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 345.9362197011045
+        value: 345.94
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 315.81287314653855
+        value: 315.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 277.54101004263595
+        value: 277.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 257.7540266952523
+        value: 257.75
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 234.5041804377724
+        value: 234.5
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 251.8081757782335
+        value: 251.81
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 234.7528908800862
+        value: 234.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.1286471426622
+        value: 107.13
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -159,31 +159,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 330.2628973155362
+        value: 330.26
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 345.9362197011045
+        value: 345.94
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 315.81287314653855
+        value: 315.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 277.54101004263595
+        value: 277.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 257.7540266952523
+        value: 257.75
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 234.5041804377724
+        value: 234.5
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 251.8081757782335
+        value: 251.81
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 234.7528908800862
+        value: 234.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.1286471426622
+        value: 107.13
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GE.yaml
+++ b/config/zones/GE.yaml
@@ -72,66 +72,51 @@ emissionFactors:
         value: 114.63672406601766
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 120.6643455749145
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 174.95051267742826
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 178.93044905447536
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 164.8681416231135
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 126.75626414010779
+        value: 126.76
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 120.66
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 174.95
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 178.93
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 164.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 203.13494391854752
+        value: 203.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 211.17559447057073
+        value: 211.18
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 120.6643455749145
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 174.95051267742826
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 178.93044905447536
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 164.8681416231135
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 126.75626414010779
+        value: 126.76
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 120.66
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 174.95
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 178.93
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 164.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 203.13494391854752
+        value: 203.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 211.17559447057073
+        value: 211.18
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 2.4219596652951795e-07
-        coal: 2.6269130389386837e-05
-        gas: 0.26000907885477026
-        geothermal: 2.016976245852379e-07
-        hydro: 0.6837193016562793
-        hydro discharge: 0.0
-        nuclear: 0.0014241948680477265
-        oil: 0.044085598518424536
-        solar: 1.0097586591440493e-05
-        unknown: 0.004324888609806786
-        wind: 0.006400004592988427
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -162,6 +147,21 @@ fallbackZoneMixes:
         solar: 1.5508313043927976e-06
         unknown: 0.009322395230355683
         wind: 0.006990158526549726
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 2.4219596652951795e-07
+        coal: 2.6269130389386837e-05
+        gas: 0.26000907885477026
+        geothermal: 2.016976245852379e-07
+        hydro: 0.6837193016562793
+        hydro discharge: 0.0
+        nuclear: 0.0014241948680477265
+        oil: 0.044085598518424536
+        solar: 1.0097586591440493e-05
+        unknown: 0.004324888609806786
+        wind: 0.006400004592988427
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:

--- a/config/zones/GF.yaml
+++ b/config/zones/GF.yaml
@@ -57,53 +57,53 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 238.8626595767095
+        value: 238.86
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 177.32988695041442
+        value: 177.33
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 186.19739912251356
+        value: 186.2
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 257.83914114555523
+        value: 257.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 245.0172956876773
+        value: 245.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 168.87843570866374
+        value: 168.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 160.61767618938424
+        value: 160.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 421.3331220412558
+        value: 421.33
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 238.8626595767095
+        value: 238.86
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 177.32988695041442
+        value: 177.33
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 186.19739912251356
+        value: 186.2
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 257.83914114555523
+        value: 257.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 245.0172956876773
+        value: 245.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 168.87843570866374
+        value: 168.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 160.61767618938424
+        value: 160.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 421.3331220412558
+        value: 421.33
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2016 average

--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -20,47 +20,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 391.36689914508645
+        value: 391.37
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 378.1579232223658
+        value: 378.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 375.25371667687864
+        value: 375.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 374.48559524237277
+        value: 374.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 378.98518140753276
+        value: 378.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 348.1753854973234
+        value: 348.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 564.7618181818182
+        value: 564.76
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 391.36689914508645
+        value: 391.37
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 378.1579232223658
+        value: 378.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 375.25371667687864
+        value: 375.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 374.48559524237277
+        value: 374.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 378.98518140753276
+        value: 378.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 348.1753854973234
+        value: 348.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 564.7618181818182
+        value: 564.76
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2016 average

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -145,31 +145,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 777.13619289585
+        value: 777.14
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 714.5710560857955
+        value: 714.57
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 723.4515473819655
+        value: 723.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 680.8004799422338
+        value: 680.8
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 557.9440378197999
+        value: 557.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
         value: 570.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 435.1882794599297
+        value: 435.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 540.3089888619854
+        value: 540.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 597.5289948938457
+        value: 597.53
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -203,31 +203,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 777.13619289585
+        value: 777.14
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 714.5710560857955
+        value: 714.57
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 723.4515473819655
+        value: 723.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 680.8004799422338
+        value: 680.8
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 557.9440378197999
+        value: 557.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
         value: 570.02
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 435.1882794599297
+        value: 435.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 540.3089888619854
+        value: 540.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 597.5289948938457
+        value: 597.53
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GT.yaml
+++ b/config/zones/GT.yaml
@@ -72,41 +72,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 181.42758260014966
+        value: 181.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 330.23509556732114
+        value: 330.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 411.55477054470884
+        value: 411.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 311.9989925861598
+        value: 312.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 173.83722298957895
+        value: 173.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 304.87273005601173
+        value: 304.87
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 181.42758260014966
+        value: 181.43
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 330.23509556732114
+        value: 330.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 411.55477054470884
+        value: 411.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 311.9989925861598
+        value: 312.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 173.83722298957895
+        value: 173.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 304.87273005601173
+        value: 304.87
     unknown:
       _url: https://docs.google.com/spreadsheets/d/1CegROfej9HqRZTfihpjPpgZTYPUHrTNgTdHWbbP3w74/edit#gid=291258352
       source: Guatemala AMM 2021-2022; IEA 2020

--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -70,25 +70,25 @@ emissionFactors:
         value: 435.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 435.35999999999996
+        value: 435.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 435.36000000000007
+        value: 435.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 435.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 435.36000000000007
+        value: 435.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 435.35999999999996
+        value: 435.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
         value: 435.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 435.36000000000007
+        value: 435.36
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -98,25 +98,25 @@ emissionFactors:
         value: 435.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 435.35999999999996
+        value: 435.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 435.36000000000007
+        value: 435.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 435.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 435.36000000000007
+        value: 435.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 435.35999999999996
+        value: 435.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
         value: 435.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 435.36000000000007
+        value: 435.36
 estimation_method: CONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/HN.yaml
+++ b/config/zones/HN.yaml
@@ -36,49 +36,49 @@ emissionFactors:
         value: 550.0403075285776
   lifecycle:
     battery discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 335.5097231167789
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 333.510659621449
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 361.68383265574556
+        value: 361.68
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 360.7879765135958
+        value: 360.79
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 361.4645234842521
+        value: 361.46
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 335.51
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 333.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 334.28643522605955
+        value: 334.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 366.79729098512394
+        value: 366.8
     hydro discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 335.5097231167789
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 333.510659621449
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 361.68383265574556
+        value: 361.68
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 360.7879765135958
+        value: 360.79
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 361.4645234842521
+        value: 361.46
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 335.51
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 333.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 334.28643522605955
+        value: 334.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 366.79729098512394
+        value: 366.8
     unknown:
       _url: https://www.iea.org/fuels-and-technologies/electricity
       source: IEA 2019; assumes 47.4% oil, 23.1% hydro, 10.6% solar, 8.3% biomass,
@@ -86,36 +86,6 @@ emissionFactors:
       value: 340
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.004822812590305817
-        coal: 0.01353721071709246
-        gas: 2.9727905437325036e-05
-        geothermal: 0.008808983980338372
-        hydro: 0.03242475923514154
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.015722996295273205
-        solar: 0.003426706128598919
-        unknown: 0.9167965484737963
-        wind: 0.004430428904932555
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.005617393993095295
-        coal: 0.005623875720900796
-        gas: 7.080231821987943e-05
-        geothermal: 0.008132750574223245
-        hydro: 0.023291110183250856
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.010883431516452881
-        solar: 0.0009095764561053702
-        unknown: 0.9391286500202161
-        wind: 0.0063428150140921406
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -161,6 +131,36 @@ fallbackZoneMixes:
         solar: 0.04344055519512237
         unknown: 0.46843837883793543
         wind: 0.03561563386042839
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.004822812590305817
+        coal: 0.01353721071709246
+        gas: 2.9727905437325036e-05
+        geothermal: 0.008808983980338372
+        hydro: 0.03242475923514154
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.015722996295273205
+        solar: 0.003426706128598919
+        unknown: 0.9167965484737963
+        wind: 0.004430428904932555
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.005617393993095295
+        coal: 0.005623875720900796
+        gas: 7.080231821987943e-05
+        geothermal: 0.008132750574223245
+        hydro: 0.023291110183250856
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.010883431516452881
+        solar: 0.0009095764561053702
+        unknown: 0.9391286500202161
+        wind: 0.0063428150140921406
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -120,27 +120,27 @@ emissionFactors:
         value: 641.08
   lifecycle:
     battery discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 363.427948425141
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 276.145046588777
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 298.49361692914437
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 328.5672633274789
+        value: 328.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 380.6135090846404
+        value: 380.61
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 363.43
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 276.15
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 298.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 336.2917574783008
+        value: 336.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 311.0833291899959
+        value: 311.08
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -172,27 +172,27 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 363.427948425141
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 276.145046588777
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 298.49361692914437
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 328.5672633274789
+        value: 328.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 380.6135090846404
+        value: 380.61
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 363.43
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 276.15
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 298.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 336.2917574783008
+        value: 336.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 311.0833291899959
+        value: 311.08
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -221,6 +221,36 @@ emissionFactors:
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.030565923847885857
+        coal: 0.15008646729647324
+        gas: 0.15190810363981816
+        geothermal: 0.002375804961596443
+        hydro: 0.2620590116593293
+        hydro discharge: 0.01924747959157986
+        nuclear: 0.09490917846615653
+        oil: 0.002028069931457711
+        solar: 0.00530582725468638
+        unknown: 0.18999005840248792
+        wind: 0.0915270371372343
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.02553449772125191
+        coal: 0.23050851291281219
+        gas: 0.12453429578972415
+        geothermal: 0.002128218573714901
+        hydro: 0.2900058684405875
+        hydro discharge: 0.018606866213218522
+        nuclear: 0.05614414418111712
+        oil: 0.001729036431491241
+        solar: 0.00495053037346795
+        unknown: 0.1664205392581284
+        wind: 0.07943727042874571
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -266,36 +296,6 @@ fallbackZoneMixes:
         solar: 0.01551924586409477
         unknown: 0.44378847459879767
         wind: 0.09435173095205274
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.030565923847885857
-        coal: 0.15008646729647324
-        gas: 0.15190810363981816
-        geothermal: 0.002375804961596443
-        hydro: 0.2620590116593293
-        hydro discharge: 0.01924747959157986
-        nuclear: 0.09490917846615653
-        oil: 0.002028069931457711
-        solar: 0.00530582725468638
-        unknown: 0.18999005840248792
-        wind: 0.0915270371372343
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.02553449772125191
-        coal: 0.23050851291281219
-        gas: 0.12453429578972415
-        geothermal: 0.002128218573714901
-        hydro: 0.2900058684405875
-        hydro discharge: 0.018606866213218522
-        nuclear: 0.05614414418111712
-        oil: 0.001729036431491241
-        solar: 0.00495053037346795
-        unknown: 0.1664205392581284
-        wind: 0.07943727042874571
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -4,6 +4,10 @@ bounding_box:
   - - 22.710531447
     - 48.6238540716
 capacity:
+  battery storage:
+    - datetime: '2024-09-01'
+      source: mavir.hu
+      value: 35.3
   biomass:
     - datetime: '2023-01-01'
       source: entsoe.eu

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -154,31 +154,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 370.5792514438418
+        value: 370.58
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 363.315441611702
+        value: 363.32
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 350.8995337557032
+        value: 350.9
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 347.78440006446596
+        value: 347.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 318.6791287766972
+        value: 318.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 299.3584352719381
+        value: 299.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 303.9110926014235
+        value: 303.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 307.07699433727754
+        value: 307.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 259.77301362294764
+        value: 259.77
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -212,31 +212,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 370.5792514438418
+        value: 370.58
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 363.315441611702
+        value: 363.32
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 350.8995337557032
+        value: 350.9
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 347.78440006446596
+        value: 347.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 318.6791287766972
+        value: 318.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 299.3584352719381
+        value: 299.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 303.9110926014235
+        value: 303.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 307.07699433727754
+        value: 307.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 259.77301362294764
+        value: 259.77
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ID.yaml
+++ b/config/zones/ID.yaml
@@ -76,25 +76,25 @@ emissionFactors:
         value: 652.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 652.3600000000002
+        value: 652.36
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -104,25 +104,25 @@ emissionFactors:
         value: 652.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 652.3600000000001
+        value: 652.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 652.3599999999998
+        value: 652.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 652.3600000000002
+        value: 652.36
 estimation_method: CONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/IE.yaml
+++ b/config/zones/IE.yaml
@@ -153,25 +153,25 @@ emissionFactors:
         value: 538.0867298588337
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 411.4843455624872
+        value: 411.48
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 387.2993565846591
+        value: 387.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 372.9115935002859
+        value: 372.91
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 352.721724832763
+        value: 352.72
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 376.86890242633064
+        value: 376.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.1092348658587
+        value: 405.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 371.58270608183375
+        value: 371.58
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -211,25 +211,25 @@ emissionFactors:
         value: 538.0867298588337
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 411.4843455624872
+        value: 411.48
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 387.2993565846591
+        value: 387.3
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 372.9115935002859
+        value: 372.91
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 352.721724832763
+        value: 352.72
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 376.86890242633064
+        value: 376.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.1092348658587
+        value: 405.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 371.58270608183375
+        value: 371.58
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IL.yaml
+++ b/config/zones/IL.yaml
@@ -118,25 +118,25 @@ emissionFactors:
         value: 573.2289528740077
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 540.1271933093738
+        value: 540.13
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 540.1274058685126
+        value: 540.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 533.1434061530422
+        value: 533.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 544.1886860485395
+        value: 544.19
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 550.8578910355652
+        value: 550.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 542.4243493689576
+        value: 542.42
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 529.9687103245003
+        value: 529.97
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -146,25 +146,25 @@ emissionFactors:
         value: 573.2289528740077
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 540.1271933093738
+        value: 540.13
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 540.1274058685126
+        value: 540.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 533.1434061530422
+        value: 533.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 544.1886860485395
+        value: 544.19
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 550.8578910355652
+        value: 550.86
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 542.4243493689576
+        value: 542.42
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 529.9687103245003
+        value: 529.97
     unknown:
       _url: https://www.iea.org/fuels-and-technologies/electricity
       source: IEA 2020; assumes 28.1% coal, 65.3% gas, 0.4% oil, 5.3% solar, 0.3%

--- a/config/zones/IM.yaml
+++ b/config/zones/IM.yaml
@@ -1,5 +1,3 @@
-timezone: Europe/Isle_of_Man
-region: Europe
 contributors:
   - VIKTORVAV99
   - AJDelusion
@@ -12,3 +10,5 @@ fallbackZoneMixes:
         gas: 0.988
         hydro: 0.007
         oil: 0.005
+region: Europe
+timezone: Europe/Isle_of_Man

--- a/config/zones/IN-DL.yaml
+++ b/config/zones/IN-DL.yaml
@@ -48,41 +48,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 533.5034388822623
+        value: 533.5
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 457.6241672212307
+        value: 457.62
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 476.27580845515206
+        value: 476.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.6597784021595
+        value: 475.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 472.4148764257316
+        value: 472.41
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 460.62033898559497
+        value: 460.62
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 533.5034388822623
+        value: 533.5
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 457.6241672212307
+        value: 457.62
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 476.27580845515206
+        value: 476.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.6597784021595
+        value: 475.66
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 472.4148764257316
+        value: 472.41
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 460.62033898559497
+        value: 460.62
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2018 average

--- a/config/zones/IN-EA.yaml
+++ b/config/zones/IN-EA.yaml
@@ -46,47 +46,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 757.2671590221448
+        value: 757.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 757.2671590221448
+        value: 757.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 757.247133040434
+        value: 757.25
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 770.4212892966405
+        value: 770.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 737.8697604348127
+        value: 737.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 744.6050279210656
+        value: 744.61
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 759.5526166915336
+        value: 759.55
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 757.2671590221448
+        value: 757.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 757.2671590221448
+        value: 757.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 757.247133040434
+        value: 757.25
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 770.4212892966405
+        value: 770.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 737.8697604348127
+        value: 737.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 744.6050279210656
+        value: 744.61
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 759.5526166915336
+        value: 759.55
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/IN-HP.yaml
+++ b/config/zones/IN-HP.yaml
@@ -30,23 +30,23 @@ emissionFactors:
     battery discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 92.67451046028728
+        value: 92.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 87.28135424295209
+        value: 87.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 77.49141863316719
+        value: 77.49
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 92.67451046028728
+        value: 92.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 87.28135424295209
+        value: 87.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 77.49141863316719
+        value: 77.49
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2021 average

--- a/config/zones/IN-KA.yaml
+++ b/config/zones/IN-KA.yaml
@@ -54,47 +54,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 571.1581301253204
+        value: 571.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 476.11209555921374
+        value: 476.11
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 393.15978346400476
+        value: 393.16
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 385.6195681182947
+        value: 385.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 459.2042079468457
+        value: 459.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 418.91602478276025
+        value: 418.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 443.234971158219
+        value: 443.23
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 571.1581301253204
+        value: 571.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 476.11209555921374
+        value: 476.11
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 393.15978346400476
+        value: 393.16
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 385.6195681182947
+        value: 385.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 459.2042079468457
+        value: 459.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 418.91602478276025
+        value: 418.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 443.234971158219
+        value: 443.23
     unknown:
       _comment: calculated 20% nuclear, 80% thermal (coal)
       source: Souther Regional Load Dispatch Center Allocation Limits 2018-2019; SRLDC

--- a/config/zones/IN-MH.yaml
+++ b/config/zones/IN-MH.yaml
@@ -85,16 +85,16 @@ emissionFactors:
         value: 725.8839591736314
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 701.7918893657841
+        value: 701.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 706.4672901442392
+        value: 706.47
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 694.8516437616474
+        value: 694.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 705.5886685624092
+        value: 705.59
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -113,16 +113,16 @@ emissionFactors:
         value: 725.8839591736314
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 701.7918893657841
+        value: 701.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 706.4672901442392
+        value: 706.47
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 694.8516437616474
+        value: 694.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 705.5886685624092
+        value: 705.59
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/IN-NE.yaml
+++ b/config/zones/IN-NE.yaml
@@ -46,47 +46,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 422.46079721423996
+        value: 422.46
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 398.9646617693819
+        value: 398.96
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 403.0612040207974
+        value: 403.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 429.33328562024434
+        value: 429.33
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 421.77002584729337
+        value: 421.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 422.46079721423996
+        value: 422.46
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 398.9646617693819
+        value: 398.96
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 403.0612040207974
+        value: 403.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 429.33328562024434
+        value: 429.33
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/IN-NO.yaml
+++ b/config/zones/IN-NO.yaml
@@ -56,41 +56,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.8712785323775
+        value: 561.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 561.7980594627782
+        value: 561.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 502.5081909618146
+        value: 502.51
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 525.8931080306676
+        value: 525.89
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 552.8026169669266
+        value: 552.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 564.0947008051687
+        value: 564.09
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.8712785323775
+        value: 561.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 561.7980594627782
+        value: 561.8
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 502.5081909618146
+        value: 502.51
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 525.8931080306676
+        value: 525.89
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 552.8026169669266
+        value: 552.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 564.0947008051687
+        value: 564.09
     unknown:
       source: CEA 2022; assumes 56% biomass, 36% hydro, 8% unknown
       value: 192

--- a/config/zones/IN-PB.yaml
+++ b/config/zones/IN-PB.yaml
@@ -55,47 +55,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 683.0193165406049
+        value: 683.02
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 449.9220529865566
+        value: 449.92
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 651.7744449793106
+        value: 651.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 586.1669509360563
+        value: 586.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 689.1763402787418
+        value: 689.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 693.3404988362022
+        value: 693.34
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 689.6171408162331
+        value: 689.62
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 683.0193165406049
+        value: 683.02
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 449.9220529865566
+        value: 449.92
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 651.7744449793106
+        value: 651.77
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 586.1669509360563
+        value: 586.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 689.1763402787418
+        value: 689.18
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 693.3404988362022
+        value: 693.34
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 689.6171408162331
+        value: 689.62
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/IN-SO.yaml
+++ b/config/zones/IN-SO.yaml
@@ -53,47 +53,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 564.4063589073857
+        value: 564.41
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 564.4063589073857
+        value: 564.41
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 564.4418551289972
+        value: 564.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 597.0799137922081
+        value: 597.08
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 504.10730799933606
+        value: 504.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 509.2196483972904
+        value: 509.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 556.0057459665567
+        value: 556.01
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 564.4063589073857
+        value: 564.41
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 564.4063589073857
+        value: 564.41
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 564.4418551289972
+        value: 564.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 597.0799137922081
+        value: 597.08
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 504.10730799933606
+        value: 504.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 509.2196483972904
+        value: 509.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 556.0057459665567
+        value: 556.01
     unknown:
       - datetime: '2020-01-01'
         source: CEA 2022; assumes 56% biomass, 36% hydro, 8% unknown

--- a/config/zones/IN-UP.yaml
+++ b/config/zones/IN-UP.yaml
@@ -76,16 +76,16 @@ emissionFactors:
         value: 727.1680612746588
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 667.211092682051
+        value: 667.21
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 665.6217013233708
+        value: 665.62
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 656.8162053297555
+        value: 656.82
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 583.8158255310517
+        value: 583.82
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -98,16 +98,16 @@ emissionFactors:
         value: 727.1680612746588
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 667.211092682051
+        value: 667.21
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 665.6217013233708
+        value: 665.62
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 656.8162053297555
+        value: 656.82
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 583.8158255310517
+        value: 583.82
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/IN-WE.yaml
+++ b/config/zones/IN-WE.yaml
@@ -66,84 +66,54 @@ emissionFactors:
       value: 45
   lifecycle:
     battery discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 686.9322901568772
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 745.10982503598
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 708.245153839166
+        value: 708.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 708.245153839166
+        value: 708.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 707.3733695131547
+        value: 707.37
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 686.93
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 745.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 748.0192890394515
+        value: 748.02
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 747.3906264861756
+        value: 747.39
     hydro discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 686.9322901568772
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 745.10982503598
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 708.245153839166
+        value: 708.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 708.245153839166
+        value: 708.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 707.3733695131547
+        value: 707.37
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 686.93
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 745.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 748.0192890394515
+        value: 748.02
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 747.3906264861756
+        value: 747.39
     unknown:
       source: CEA 2022; assumes 56% biomass, 36% hydro, 8% unknown
       value: 192
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.1266453354528477e-06
-        coal: 0.8050859391144821
-        gas: 0.04788703268471147
-        geothermal: 1.9818115124704651e-07
-        hydro: 0.049675101586788416
-        hydro discharge: 0.0
-        nuclear: 0.02693260226461311
-        oil: 1.452340097202096e-05
-        solar: 0.025259513867302505
-        unknown: 0.000993240504309562
-        wind: 0.04415072198931224
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 5.739031033132005e-07
-        coal: 0.887665347808708
-        gas: 0.031056018463866287
-        geothermal: 1.0089703605961209e-07
-        hydro: 0.04095961682941275
-        hydro discharge: 0.0
-        nuclear: 0.02483275926928702
-        oil: 1.026257195556136e-05
-        solar: 0.009773599556407605
-        unknown: 0.0013972621140097155
-        wind: 0.0043044522789579265
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -189,6 +159,36 @@ fallbackZoneMixes:
         solar: 0.01959473261418327
         unknown: 0.0008299707664044964
         wind: 0.054264775511731075
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.1266453354528477e-06
+        coal: 0.8050859391144821
+        gas: 0.04788703268471147
+        geothermal: 1.9818115124704651e-07
+        hydro: 0.049675101586788416
+        hydro discharge: 0.0
+        nuclear: 0.02693260226461311
+        oil: 1.452340097202096e-05
+        solar: 0.025259513867302505
+        unknown: 0.000993240504309562
+        wind: 0.04415072198931224
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 5.739031033132005e-07
+        coal: 0.887665347808708
+        gas: 0.031056018463866287
+        geothermal: 1.0089703605961209e-07
+        hydro: 0.04095961682941275
+        hydro discharge: 0.0
+        nuclear: 0.02483275926928702
+        oil: 1.026257195556136e-05
+        solar: 0.009773599556407605
+        unknown: 0.0013972621140097155
+        wind: 0.0043044522789579265
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/IN.yaml
+++ b/config/zones/IN.yaml
@@ -49,41 +49,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 647.3973804104088
+        value: 647.4
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 647.401721974111
+        value: 647.4
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 640.5930183672864
+        value: 640.59
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 633.677954773214
+        value: 633.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 639.1688687296418
+        value: 639.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 659.7224745286302
+        value: 659.72
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 647.3973804104088
+        value: 647.4
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 647.401721974111
+        value: 647.4
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 640.5930183672864
+        value: 640.59
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 633.677954773214
+        value: 633.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 639.1688687296418
+        value: 639.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 659.7224745286302
+        value: 659.72
     unknown:
       source: assumes 43% solar PV and 57% wind
       value: 26

--- a/config/zones/IQ.yaml
+++ b/config/zones/IQ.yaml
@@ -29,17 +29,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 528.3203454253005
+        value: 528.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 502.5211622995701
+        value: 502.52
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 528.3203454253005
+        value: 528.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 502.5211622995701
+        value: 502.52
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2018 average

--- a/config/zones/IS.yaml
+++ b/config/zones/IS.yaml
@@ -83,27 +83,27 @@ emissionFactors:
         value: 0.01866069813401729
   lifecycle:
     battery discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 28.383186292102042
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 28.186048526808047
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 27.86594965623318
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 27.93636813319271
+        value: 27.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 27.93636813319271
+        value: 27.94
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 28.38
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 28.19
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 27.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 27.476626925048286
+        value: 27.48
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.865340906120153
+        value: 27.87
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -117,33 +117,63 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 28.383186292102042
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 28.186048526808047
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 27.86594965623318
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 27.93636813319271
+        value: 27.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 27.93636813319271
+        value: 27.94
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 28.38
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 28.19
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 27.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 27.476626925048286
+        value: 27.48
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.865340906120153
+        value: 27.87
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.2792542897240735
+        hydro: 0.7207031681342156
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 4.161225883196948e-05
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.2792542897240735
+        hydro: 0.7207031681342156
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 4.161225883196948e-05
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -186,36 +216,6 @@ fallbackZoneMixes:
         hydro discharge: 0.0
         nuclear: 0.0
         oil: 2.382154167634375e-05
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.2792542897240735
-        hydro: 0.7207031681342156
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 4.161225883196948e-05
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.2792542897240735
-        hydro: 0.7207031681342156
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 4.161225883196948e-05
         solar: 0.0
         unknown: 0.0
         wind: 0.0

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 242.04135540359468
+        value: 242.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 252.789540530316
+        value: 252.79
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 288.95397191400826
+        value: 288.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 301.71448105334736
+        value: 301.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 312.56871812469615
+        value: 312.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 291.16098253400673
+        value: 291.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 296.03090421348304
+        value: 296.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 346.3353660057361
+        value: 346.34
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 284.5217314078419
+        value: 284.52
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 242.04135540359468
+        value: 242.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 252.789540530316
+        value: 252.79
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 288.95397191400826
+        value: 288.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 301.71448105334736
+        value: 301.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 312.56871812469615
+        value: 312.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 291.16098253400673
+        value: 291.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 296.03090421348304
+        value: 296.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 346.3353660057361
+        value: 346.34
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 284.5217314078419
+        value: 284.52
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 609.2007680962776
+        value: 609.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 560.6049487614204
+        value: 560.6
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 567.9591268146465
+        value: 567.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 439.51328806759176
+        value: 439.51
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 440.96408324964966
+        value: 440.96
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 445.55686763763157
+        value: 445.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 399.4200441426917
+        value: 399.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 409.2044507959134
+        value: 409.2
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 300.63153421854065
+        value: 300.63
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 609.2007680962776
+        value: 609.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 560.6049487614204
+        value: 560.6
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 567.9591268146465
+        value: 567.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 439.51328806759176
+        value: 439.51
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 440.96408324964966
+        value: 440.96
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 445.55686763763157
+        value: 445.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 399.4200441426917
+        value: 399.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 409.2044507959134
+        value: 409.2
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 300.63153421854065
+        value: 300.63
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 334.05197772825665
+        value: 334.05
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 406.4916415271094
+        value: 406.49
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 432.405330226993
+        value: 432.41
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 378.5647763074362
+        value: 378.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 323.5666082112321
+        value: 323.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 293.39133946751923
+        value: 293.39
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 347.5586623843775
+        value: 347.56
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 354.37127172602175
+        value: 354.37
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 275.06393574769885
+        value: 275.06
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 334.05197772825665
+        value: 334.05
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 406.4916415271094
+        value: 406.49
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 432.405330226993
+        value: 432.41
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 378.5647763074362
+        value: 378.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 323.5666082112321
+        value: 323.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 293.39133946751923
+        value: 293.39
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 347.5586623843775
+        value: 347.56
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 354.37127172602175
+        value: 354.37
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 275.06393574769885
+        value: 275.06
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 619.1967041276497
+        value: 619.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 591.1329316302604
+        value: 591.13
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 629.515122452915
+        value: 629.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 635.9560705299374
+        value: 635.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 578.0498711108078
+        value: 578.05
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 600.0779263554892
+        value: 600.08
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 573.4004154133247
+        value: 573.4
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 583.3956955962435
+        value: 583.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 507.211570119121
+        value: 507.21
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 619.1967041276497
+        value: 619.2
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 591.1329316302604
+        value: 591.13
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 629.515122452915
+        value: 629.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 635.9560705299374
+        value: 635.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 578.0498711108078
+        value: 578.05
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 600.0779263554892
+        value: 600.08
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 573.4004154133247
+        value: 573.4
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 583.3956955962435
+        value: 583.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 507.211570119121
+        value: 507.21
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 471.89126244598907
+        value: 471.89
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 393.9441032975765
+        value: 393.94
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 341.74635758239907
+        value: 341.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 233.13940170940174
+        value: 233.14
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 375.34464283144894
+        value: 375.34
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 376.9892177433239
+        value: 376.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 383.09388802668883
+        value: 383.09
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 415.8266223496382
+        value: 415.83
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 326.18473275305234
+        value: 326.18
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 471.89126244598907
+        value: 471.89
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 393.9441032975765
+        value: 393.94
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 341.74635758239907
+        value: 341.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 233.13940170940174
+        value: 233.14
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 375.34464283144894
+        value: 375.34
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 376.9892177433239
+        value: 376.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 383.09388802668883
+        value: 383.09
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 415.8266223496382
+        value: 415.83
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 326.18473275305234
+        value: 326.18
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SO.yaml
+++ b/config/zones/IT-SO.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 304.684963328947
+        value: 304.68
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 313.23586477505967
+        value: 313.24
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 160.00759361604668
+        value: 160.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 129.54644841284693
+        value: 129.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 365.5628932463208
+        value: 365.56
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 357.9554077066104
+        value: 357.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 389.0145036008951
+        value: 389.01
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 442.3089533001716
+        value: 442.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 356.39494751761714
+        value: 356.39
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 304.684963328947
+        value: 304.68
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 313.23586477505967
+        value: 313.24
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 160.00759361604668
+        value: 160.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 129.54644841284693
+        value: 129.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 365.5628932463208
+        value: 365.56
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 357.9554077066104
+        value: 357.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 389.0145036008951
+        value: 389.01
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 442.3089533001716
+        value: 442.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 356.39494751761714
+        value: 356.39
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -101,31 +101,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 383.21922513897977
+        value: 383.22
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 415.44953520950077
+        value: 415.45
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 426.08812023564957
+        value: 426.09
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 143.32840015578128
+        value: 143.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 353.6354026311637
+        value: 353.64
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 339.38101807117323
+        value: 339.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.72030567119674
+        value: 363.72
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 387.78672111206623
+        value: 387.79
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 288.1818471317999
+        value: 288.18
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -159,31 +159,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 383.21922513897977
+        value: 383.22
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 415.44953520950077
+        value: 415.45
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 426.08812023564957
+        value: 426.09
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 143.32840015578128
+        value: 143.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 353.6354026311637
+        value: 353.64
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 339.38101807117323
+        value: 339.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 363.72030567119674
+        value: 363.72
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 387.78672111206623
+        value: 387.79
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 288.1818471317999
+        value: 288.18
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 546.5387723390452
+        value: 546.54
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.9900006037426
+        value: 545.99
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 545.1461569781733
+        value: 545.15
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 518.6511289255802
+        value: 518.65
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 513.0469607569149
+        value: 513.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 508.3569166775055
+        value: 508.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 478.72196894648187
+        value: 478.72
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 546.5387723390452
+        value: 546.54
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 545.9900006037426
+        value: 545.99
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 545.1461569781733
+        value: 545.15
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 518.6511289255802
+        value: 518.65
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 513.0469607569149
+        value: 513.05
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 508.3569166775055
+        value: 508.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 478.72196894648187
+        value: 478.72
     unknown:
       _comment: 'Source: Derived from 2016-2019 Chubu area supply statistics and 2017-2018
         Chubu Electric report'

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -26,47 +26,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 562.4545215946243
+        value: 562.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 525.3215791863836
+        value: 525.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 521.0704325213983
+        value: 521.07
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 516.5891396553358
+        value: 516.59
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 470.7311033765594
+        value: 470.73
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 498.7506914391316
+        value: 498.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 466.1834685343868
+        value: 466.18
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 562.4545215946243
+        value: 562.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 525.3215791863836
+        value: 525.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 521.0704325213983
+        value: 521.07
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 516.5891396553358
+        value: 516.59
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 470.7311033765594
+        value: 470.73
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 498.7506914391316
+        value: 498.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 466.1834685343868
+        value: 466.18
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 504.13152647328883
+        value: 504.13
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 510.48489945175163
+        value: 510.48
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 506.4689658873527
+        value: 506.47
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 531.4417304938096
+        value: 531.44
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.2508805263289
+        value: 475.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 459.8553007836858
+        value: 459.86
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 466.52763480788957
+        value: 466.53
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 504.13152647328883
+        value: 504.13
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 510.48489945175163
+        value: 510.48
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 506.4689658873527
+        value: 506.47
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 531.4417304938096
+        value: 531.44
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.2508805263289
+        value: 475.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 459.8553007836858
+        value: 459.86
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 466.52763480788957
+        value: 466.53
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 451.2476536858971
+        value: 451.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 448.1286037339714
+        value: 448.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 442.5173908499862
+        value: 442.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 452.9357543942432
+        value: 452.94
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 459.38335505808857
+        value: 459.38
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 464.14392307373
+        value: 464.14
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 454.79782906657226
+        value: 454.8
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 451.2476536858971
+        value: 451.25
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 448.1286037339714
+        value: 448.13
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 442.5173908499862
+        value: 442.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 452.9357543942432
+        value: 452.94
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 459.38335505808857
+        value: 459.38
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 464.14392307373
+        value: 464.14
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 454.79782906657226
+        value: 454.8
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -76,25 +76,25 @@ emissionFactors:
         value: 456.0686288827389
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 497.1396518056959
+        value: 497.14
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 424.3590143202138
+        value: 424.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.45580074333856
+        value: 414.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 456.5762777759375
+        value: 456.58
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 403.1330199653851
+        value: 403.13
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 420.7006552290664
+        value: 420.7
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 370.38423060828137
+        value: 370.38
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -104,25 +104,25 @@ emissionFactors:
         value: 456.0686288827389
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 497.1396518056959
+        value: 497.14
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 424.3590143202138
+        value: 424.36
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.45580074333856
+        value: 414.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 456.5762777759375
+        value: 456.58
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 403.1330199653851
+        value: 403.13
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 420.7006552290664
+        value: 420.7
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 370.38423060828137
+        value: 370.38
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -85,22 +85,22 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 410.00003569729006
+        value: 410.0
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 365.12158822434714
+        value: 365.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 359.84548701868243
+        value: 359.85
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 310.4190221731244
+        value: 310.42
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
         value: 504.86404052782575
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 458.1001166666342
+        value: 458.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
         value: 447.4085111237463
@@ -115,29 +115,29 @@ emissionFactors:
         value: 388.75244760996026
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 395.359557731966
+        value: 395.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 309.35689366735227
+        value: 309.36
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 410.00003569729006
+        value: 410.0
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 365.12158822434714
+        value: 365.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 359.84548701868243
+        value: 359.85
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 310.4190221731244
+        value: 310.42
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
         value: 504.86404052782575
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 458.1001166666342
+        value: 458.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
         value: 447.4085111237463
@@ -152,42 +152,12 @@ emissionFactors:
         value: 388.75244760996026
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 395.359557731966
+        value: 395.36
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 309.35689366735227
+        value: 309.36
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.03394897773719484
-        coal: 0.22632657220005892
-        gas: 0.2873090098066224
-        geothermal: 0.01194500543331599
-        hydro: 0.045894001247654526
-        hydro discharge: 0.0014535498433951002
-        nuclear: 0.24481052728855904
-        oil: 0.023261336772847918
-        solar: 0.11795166084263495
-        unknown: 6.823822454306038e-09
-        wind: 0.007099343743477133
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.029980656680773175
-        coal: 0.2034428315861572
-        gas: 0.2291408699669696
-        geothermal: 0.012313191688658286
-        hydro: 0.04068847020057973
-        hydro discharge: 0.0005706782834496352
-        nuclear: 0.33576216186990826
-        oil: 0.020344290025776444
-        solar: 0.12049004039136982
-        unknown: 4.648902623869007e-08
-        wind: 0.007266772492712764
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -233,6 +203,36 @@ fallbackZoneMixes:
         solar: 0.10435539230920005
         unknown: 0.0
         wind: 0.006433991842485429
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.03394897773719484
+        coal: 0.22632657220005892
+        gas: 0.2873090098066224
+        geothermal: 0.01194500543331599
+        hydro: 0.045894001247654526
+        hydro discharge: 0.0014535498433951002
+        nuclear: 0.24481052728855904
+        oil: 0.023261336772847918
+        solar: 0.11795166084263495
+        unknown: 6.823822454306038e-09
+        wind: 0.007099343743477133
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.029980656680773175
+        coal: 0.2034428315861572
+        gas: 0.2291408699669696
+        geothermal: 0.012313191688658286
+        hydro: 0.04068847020057973
+        hydro discharge: 0.0005706782834496352
+        nuclear: 0.33576216186990826
+        oil: 0.020344290025776444
+        solar: 0.12049004039136982
+        unknown: 4.648902623869007e-08
+        wind: 0.007266772492712764
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -24,47 +24,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 608.2263899513495
+        value: 608.23
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 604.6844918175224
+        value: 604.68
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 609.0568577551368
+        value: 609.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 605.8369451308537
+        value: 605.84
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 600.0357284003023
+        value: 600.04
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 596.9927364298936
+        value: 596.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 590.6490157566238
+        value: 590.65
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 608.2263899513495
+        value: 608.23
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 604.6844918175224
+        value: 604.68
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 609.0568577551368
+        value: 609.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 605.8369451308537
+        value: 605.84
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 600.0357284003023
+        value: 600.04
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 596.9927364298936
+        value: 596.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 590.6490157566238
+        value: 590.65
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -30,53 +30,53 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 351.4175259644989
+        value: 351.42
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 325.2351897871563
+        value: 325.24
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 363.9627295676005
+        value: 363.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 346.15015029528826
+        value: 346.15
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 372.09250192323094
+        value: 372.09
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 412.96919672344364
+        value: 412.97
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 416.97640194099125
+        value: 416.98
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 404.67285462555685
+        value: 404.67
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 351.4175259644989
+        value: 351.42
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 325.2351897871563
+        value: 325.24
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 363.9627295676005
+        value: 363.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 346.15015029528826
+        value: 346.15
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 372.09250192323094
+        value: 372.09
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 412.96919672344364
+        value: 412.97
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 416.97640194099125
+        value: 416.98
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 404.67285462555685
+        value: 404.67
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-TH.yaml
+++ b/config/zones/JP-TH.yaml
@@ -28,47 +28,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 505.8118612156556
+        value: 505.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 496.26717517761267
+        value: 496.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 491.4156739859779
+        value: 491.42
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 514.9240875854138
+        value: 514.92
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 483.66520085376027
+        value: 483.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 484.4332621014588
+        value: 484.43
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 481.01287299953236
+        value: 481.01
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 505.8118612156556
+        value: 505.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 496.26717517761267
+        value: 496.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 491.4156739859779
+        value: 491.42
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 514.9240875854138
+        value: 514.92
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 483.66520085376027
+        value: 483.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 484.4332621014588
+        value: 484.43
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 481.01287299953236
+        value: 481.01
     unknown:
       source: Enerdata 2022 Japanese National Average
       value: 462

--- a/config/zones/JP-TK.yaml
+++ b/config/zones/JP-TK.yaml
@@ -75,25 +75,25 @@ emissionFactors:
         value: 563.3910376169232
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 575.1899595934004
+        value: 575.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.6880765627718
+        value: 561.69
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 554.8366516530738
+        value: 554.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 558.1721594040803
+        value: 558.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 549.0283594416643
+        value: 549.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 546.8209898030393
+        value: 546.82
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 536.0630973160625
+        value: 536.06
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -103,25 +103,25 @@ emissionFactors:
         value: 563.3910376169232
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 575.1899595934004
+        value: 575.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.6880765627718
+        value: 561.69
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 554.8366516530738
+        value: 554.84
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 558.1721594040803
+        value: 558.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 549.0283594416643
+        value: 549.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 546.8209898030393
+        value: 546.82
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 536.0630973160625
+        value: 536.06
 estimation_method: RECONSTRUCT_BREAKDOWN
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 526.4198372746504
+        value: 526.42
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 502.48009317162956
+        value: 502.48
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 507.9912358111145
+        value: 507.99
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 513.2831994238893
+        value: 513.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.793289728023
+        value: 475.79
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 487.4804241103259
+        value: 487.48
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 459.7248847672852
+        value: 459.72
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 526.4198372746504
+        value: 526.42
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 502.48009317162956
+        value: 502.48
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 507.9912358111145
+        value: 507.99
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 513.2831994238893
+        value: 513.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 475.793289728023
+        value: 475.79
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 487.4804241103259
+        value: 487.48
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 459.7248847672852
+        value: 459.72
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -139,25 +139,25 @@ emissionFactors:
         value: 490.36674359237577
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 499.25543716618233
+        value: 499.26
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 499.25543716618233
+        value: 499.26
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 484.0951149176079
+        value: 484.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 483.9099821634787
+        value: 483.91
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 455.17343395268006
+        value: 455.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 448.8495593846487
+        value: 448.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 421.93595411096464
+        value: 421.94
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -167,25 +167,25 @@ emissionFactors:
         value: 490.36674359237577
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 499.25543716618233
+        value: 499.26
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 499.25543716618233
+        value: 499.26
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 484.0951149176079
+        value: 484.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 483.9099821634787
+        value: 483.91
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 455.17343395268006
+        value: 455.17
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 448.8495593846487
+        value: 448.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 421.93595411096464
+        value: 421.94
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/KW.yaml
+++ b/config/zones/KW.yaml
@@ -74,26 +74,26 @@ emissionFactors:
     battery discharge:
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 549.9999999999999
+        value: 550.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 550.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 549.9999999999999
+        value: 550.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
         value: 550.0
     hydro discharge:
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 549.9999999999999
+        value: 550.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 550.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 549.9999999999999
+        value: 550.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
         value: 550.0

--- a/config/zones/LK.yaml
+++ b/config/zones/LK.yaml
@@ -64,47 +64,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 394.6545368020408
+        value: 394.65
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 416.11777188970393
+        value: 416.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 394.6545368020408
+        value: 394.65
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -138,31 +138,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 432.04115643694996
+        value: 432.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 391.8347568144925
+        value: 391.83
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 363.40004617419515
+        value: 363.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 411.71060842433485
+        value: 411.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 483.1066205499674
+        value: 483.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 264.972214101542
+        value: 264.97
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 265.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 265.9720619611165
+        value: 265.97
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 200.00955251336825
+        value: 200.01
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -194,31 +194,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 432.04115643694996
+        value: 432.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 391.8347568144925
+        value: 391.83
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 363.40004617419515
+        value: 363.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 411.71060842433485
+        value: 411.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 483.1066205499674
+        value: 483.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 264.972214101542
+        value: 264.97
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 265.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 265.9720619611165
+        value: 265.97
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 200.00955251336825
+        value: 200.01
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -108,31 +108,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 282.4713443466483
+        value: 282.47
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 261.7626108139874
+        value: 261.76
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 429.7514553370938
+        value: 429.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 447.1409185234481
+        value: 447.14
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 382.5239852692106
+        value: 382.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 335.3784136466197
+        value: 335.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 334.2179672171714
+        value: 334.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 358.3466199312177
+        value: 358.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 289.3726105323978
+        value: 289.37
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -161,31 +161,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 282.4713443466483
+        value: 282.47
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 261.7626108139874
+        value: 261.76
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 429.7514553370938
+        value: 429.75
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 447.1409185234481
+        value: 447.14
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 382.5239852692106
+        value: 382.52
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 335.3784136466197
+        value: 335.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 334.2179672171714
+        value: 334.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 358.3466199312177
+        value: 358.35
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 289.3726105323978
+        value: 289.37
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -128,31 +128,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 402.25429033505253
+        value: 402.25
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 421.3048631143344
+        value: 421.3
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 327.4843888614977
+        value: 327.48
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 428.0529368242227
+        value: 428.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 366.3245080798283
+        value: 366.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 277.35399349070775
+        value: 277.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 300.5834789976773
+        value: 300.58
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 286.57308101996426
+        value: 286.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 198.23232690902805
+        value: 198.23
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -184,31 +184,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 402.25429033505253
+        value: 402.25
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 421.3048631143344
+        value: 421.3
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 327.4843888614977
+        value: 327.48
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 428.0529368242227
+        value: 428.05
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 366.3245080798283
+        value: 366.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 277.35399349070775
+        value: 277.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 300.5834789976773
+        value: 300.58
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 286.57308101996426
+        value: 286.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 198.23232690902805
+        value: 198.23
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/MD.yaml
+++ b/config/zones/MD.yaml
@@ -74,55 +74,85 @@ emissionFactors:
         value: 424.6352528711844
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 578.5906664588244
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 595.7233649230349
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 624.5045034332204
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 533.1921256188773
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 596.4458120596099
+        value: 596.45
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 578.59
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 595.72
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 624.5
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 533.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 463.5468690872586
+        value: 463.55
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 441.21293094351086
+        value: 441.21
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 578.5906664588244
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 595.7233649230349
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 624.5045034332204
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 533.1921256188773
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 596.4458120596099
+        value: 596.45
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 578.59
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 595.72
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 624.5
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 533.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 463.5468690872586
+        value: 463.55
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 441.21293094351086
+        value: 441.21
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
       value: 30.25
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.006788777898653847
+        coal: 0.00028132785852574886
+        gas: 0.3443663050585338
+        geothermal: 0.0
+        hydro: 0.04106494236363421
+        hydro discharge: 2.4491808668927983e-07
+        nuclear: 0.00045837457712401644
+        oil: 2.061739825802412e-07
+        solar: 6.365102817913487e-08
+        unknown: 0.6070352618006363
+        wind: 5.4988953474756956e-06
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0006323264036209648
+        coal: 0.04981617891337937
+        gas: 0.1441303894734955
+        geothermal: 0.0
+        hydro: 0.05808573170879668
+        hydro discharge: 1.7718925614004492e-05
+        nuclear: 0.08095866766762916
+        oil: 2.1566154111234828e-05
+        solar: 5.2317709935447236e-05
+        unknown: 0.6642402493738373
+        wind: 0.0020439489222897397
     - _source: Electricity Maps, 2019 average
       datetime: '2019-01-01'
       value:
@@ -168,36 +198,6 @@ fallbackZoneMixes:
         solar: 2.9811581706882743e-05
         unknown: 0.41077179769700534
         wind: 6.621194419886718e-05
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.006788777898653847
-        coal: 0.00028132785852574886
-        gas: 0.3443663050585338
-        geothermal: 0.0
-        hydro: 0.04106494236363421
-        hydro discharge: 2.4491808668927983e-07
-        nuclear: 0.00045837457712401644
-        oil: 2.061739825802412e-07
-        solar: 6.365102817913487e-08
-        unknown: 0.6070352618006363
-        wind: 5.4988953474756956e-06
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0006323264036209648
-        coal: 0.04981617891337937
-        gas: 0.1441303894734955
-        geothermal: 0.0
-        hydro: 0.05808573170879668
-        hydro discharge: 1.7718925614004492e-05
-        nuclear: 0.08095866766762916
-        oil: 2.1566154111234828e-05
-        solar: 5.2317709935447236e-05
-        unknown: 0.6642402493738373
-        wind: 0.0020439489222897397
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ME.yaml
+++ b/config/zones/ME.yaml
@@ -73,31 +73,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 605.0269140569947
+        value: 605.03
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 608.7264544013844
+        value: 608.73
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 643.2651047481363
+        value: 643.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 501.94153765618535
+        value: 501.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 445.13076974150505
+        value: 445.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 453.12650708959933
+        value: 453.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 392.64328819744065
+        value: 392.64
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 454.6913982881004
+        value: 454.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 408.20146801756
+        value: 408.2
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -105,31 +105,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 605.0269140569947
+        value: 605.03
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 608.7264544013844
+        value: 608.73
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 643.2651047481363
+        value: 643.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 501.94153765618535
+        value: 501.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 445.13076974150505
+        value: 445.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 453.12650708959933
+        value: 453.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 392.64328819744065
+        value: 392.64
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 454.6913982881004
+        value: 454.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 408.20146801756
+        value: 408.2
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/MK.yaml
+++ b/config/zones/MK.yaml
@@ -84,28 +84,28 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 518.8995009731651
+        value: 518.9
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 593.3404582932629
+        value: 593.34
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 519.728512077063
+        value: 519.73
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 571.6346845407165
+        value: 571.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 537.1928626662724
+        value: 537.19
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 492.3895171212993
+        value: 492.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 551.1328103440648
+        value: 551.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 508.28026016109953
+        value: 508.28
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -113,28 +113,28 @@ emissionFactors:
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 518.8995009731651
+        value: 518.9
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 593.3404582932629
+        value: 593.34
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 519.728512077063
+        value: 519.73
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 571.6346845407165
+        value: 571.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 537.1928626662724
+        value: 537.19
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 492.3895171212993
+        value: 492.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 551.1328103440648
+        value: 551.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 508.28026016109953
+        value: 508.28
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/MN.yaml
+++ b/config/zones/MN.yaml
@@ -36,11 +36,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 712.2357223753118
+        value: 712.24
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 712.2357223753118
+        value: 712.24
     unknown:
       - _url: https://www.iea.org/fuels-and-technologies/electricity
         datetime: '2020-01-01'

--- a/config/zones/MQ.yaml
+++ b/config/zones/MQ.yaml
@@ -20,47 +20,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 461.87180848140866
+        value: 461.87
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 463.84443075053474
+        value: 463.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 450.3154455214763
+        value: 450.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 410.1319673108312
+        value: 410.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 414.16982524111916
+        value: 414.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 405.6750821861175
+        value: 405.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 403.576049443859
+        value: 403.58
     hydro discharge:
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 461.87180848140866
+        value: 461.87
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 463.84443075053474
+        value: 463.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 450.3154455214763
+        value: 450.32
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 410.1319673108312
+        value: 410.13
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 414.16982524111916
+        value: 414.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 405.6750821861175
+        value: 405.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 403.576049443859
+        value: 403.58
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2016 average

--- a/config/zones/MX-BC.yaml
+++ b/config/zones/MX-BC.yaml
@@ -16,11 +16,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 341.3015715530571
+        value: 341.3
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 341.3015715530571
+        value: 341.3
     unknown:
       - datetime: '2017-01-01'
         source: "Electricity Maps & Dra. Gabriela Mu\xF1oz Mel\xE9ndez"

--- a/config/zones/MX-CE.yaml
+++ b/config/zones/MX-CE.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.0005664584471
+        value: 411.0
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.0005664584471
+        value: 411.0
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-NE.yaml
+++ b/config/zones/MX-NE.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99059690347167
+        value: 410.99
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99059690347167
+        value: 410.99
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-NO.yaml
+++ b/config/zones/MX-NO.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99989013797256
+        value: 411.0
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99989013797256
+        value: 411.0
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-NW.yaml
+++ b/config/zones/MX-NW.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.000045410926
+        value: 411.0
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.000045410926
+        value: 411.0
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-OC.yaml
+++ b/config/zones/MX-OC.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99543128863866
+        value: 411.0
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.99543128863866
+        value: 411.0
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-OR.yaml
+++ b/config/zones/MX-OR.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.9945940251405
+        value: 410.99
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 410.9945940251405
+        value: 410.99
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MX-PN.yaml
+++ b/config/zones/MX-PN.yaml
@@ -20,11 +20,11 @@ emissionFactors:
     battery discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.00069638052224
+        value: 411.0
     hydro discharge:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 411.00069638052224
+        value: 411.0
     unknown:
       - comment: Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2%
           coal, 4.3% solar, 5.9% wind, 1.5% other renewables with default IPCC 2014

--- a/config/zones/MY-EM.yaml
+++ b/config/zones/MY-EM.yaml
@@ -1,8 +1,8 @@
 aggregates_displayed:
-  - yearly # The estimation model will only have variation at a yearly aggregation
-country: MY
+  - yearly
 contributors:
   - FelixDQ
+country: MY
 estimation_method: CONSTRUCT_BREAKDOWN
 region: Asia
 timezone: Asia/Kuala_Lumpur

--- a/config/zones/MY-WM.yaml
+++ b/config/zones/MY-WM.yaml
@@ -45,51 +45,66 @@ emissionFactors:
         value: 583.6707149512696
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 655.9690125396723
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 655.587486382122
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 680.5189776729692
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 655.9281772050779
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 641.7211554349323
+        value: 641.72
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 655.97
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 655.59
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 680.52
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 655.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 644.385036903156
+        value: 644.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 649.5302584215974
+        value: 649.53
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 655.9690125396723
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 655.587486382122
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 680.5189776729692
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 655.9281772050779
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 641.7211554349323
+        value: 641.72
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 655.97
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 655.59
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 680.52
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 655.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 644.385036903156
+        value: 644.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 649.5302584215974
+        value: 649.53
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.537629454942522
+        gas: 0.3981806594897329
+        geothermal: 0.0
+        hydro: 0.05770777566482798
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0025736374311648063
+        solar: 0.0
+        unknown: 0.0039084672442364935
+        wind: 0.0
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -150,21 +165,6 @@ fallbackZoneMixes:
         solar: 0.008815501432813292
         unknown: 0.001795920685659417
         wind: 9.392462867001083e-06
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.537629454942522
-        gas: 0.3981806594897329
-        geothermal: 0.0
-        hydro: 0.05770777566482798
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0025736374311648063
-        solar: 0.0
-        unknown: 0.0039084672442364935
-        wind: 0.0
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/MY.yaml
+++ b/config/zones/MY.yaml
@@ -1,11 +1,8 @@
 country: MY
-disclaimer: 'This zone is partially using fully estimated data from MY-EM'
-estimation_method:
-  CONSTRUCT_BREAKDOWN
-  # We need either a parser or a estimation method for the frontend to display any data.
-  # This just has to be a truthy value but we'll use the same as the subzone estimation method for simplicity.
+disclaimer: This zone is partially using fully estimated data from MY-EM
+estimation_method: CONSTRUCT_BREAKDOWN
+region: Asia
 subZoneNames:
   - MY-WM
   - MY-EM
-region: Asia
 timezone: Asia/Kuala_Lumpur

--- a/config/zones/NA.yaml
+++ b/config/zones/NA.yaml
@@ -34,17 +34,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 39.667073073513784
+        value: 39.67
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 42.97891970183084
+        value: 42.98
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 39.667073073513784
+        value: 39.67
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 42.97891970183084
+        value: 42.98
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2018 average

--- a/config/zones/NG.yaml
+++ b/config/zones/NG.yaml
@@ -50,23 +50,23 @@ emissionFactors:
     battery discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 377.6844057534393
+        value: 377.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 372.0606908243157
+        value: 372.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.6791709623325
+        value: 377.68
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 377.6844057534393
+        value: 377.68
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 372.0606908243157
+        value: 372.06
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.6791709623325
+        value: 377.68
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2021 average

--- a/config/zones/NI.yaml
+++ b/config/zones/NI.yaml
@@ -120,25 +120,25 @@ emissionFactors:
         value: 262.20576269306457
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 167.83748465478564
+        value: 167.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 284.238123714655
+        value: 284.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 320.57386470937
+        value: 320.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 208.63341186111526
+        value: 208.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 202.5544697638448
+        value: 202.55
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 249.0440767186515
+        value: 249.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 331.72057639850027
+        value: 331.72
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -148,25 +148,25 @@ emissionFactors:
         value: 262.20576269306457
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 167.83748465478564
+        value: 167.84
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 284.238123714655
+        value: 284.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 320.57386470937
+        value: 320.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 208.63341186111526
+        value: 208.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 202.5544697638448
+        value: 202.55
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 249.0440767186515
+        value: 249.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 331.72057639850027
+        value: 331.72
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -132,31 +132,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 480.0864341969498
+        value: 480.09
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 496.28657173871085
+        value: 496.29
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 471.72351668217084
+        value: 471.72
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 459.5309109313766
+        value: 459.53
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.65549428592664
+        value: 414.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 381.32560516172396
+        value: 381.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 388.4555749710315
+        value: 388.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 357.4093686862732
+        value: 357.41
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 301.10979288079943
+        value: 301.11
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -186,31 +186,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 480.0864341969498
+        value: 480.09
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 496.28657173871085
+        value: 496.29
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 471.72351668217084
+        value: 471.72
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 459.5309109313766
+        value: 459.53
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.65549428592664
+        value: 414.66
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 381.32560516172396
+        value: 381.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 388.4555749710315
+        value: 388.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 357.4093686862732
+        value: 357.41
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 301.10979288079943
+        value: 301.11
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/NO-NO1.yaml
+++ b/config/zones/NO-NO1.yaml
@@ -84,31 +84,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 31.74458415907246
+        value: 31.74
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 33.11922066985451
+        value: 33.12
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 33.26266601606306
+        value: 33.26
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 36.88047336820282
+        value: 36.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 35.53099576869086
+        value: 35.53
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 28.99816671765955
+        value: 29.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.290426174819853
+        value: 31.29
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 30.283040714212152
+        value: 30.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 29.255570305846796
+        value: 29.26
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -125,31 +125,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 31.74458415907246
+        value: 31.74
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 33.11922066985451
+        value: 33.12
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 33.26266601606306
+        value: 33.26
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 36.88047336820282
+        value: 36.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 35.53099576869086
+        value: 35.53
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 28.99816671765955
+        value: 29.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.290426174819853
+        value: 31.29
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 30.283040714212152
+        value: 30.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 29.255570305846796
+        value: 29.26
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -90,31 +90,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 32.29775175733491
+        value: 32.3
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 34.765193183740536
+        value: 34.77
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 38.188602637927
+        value: 38.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 45.190455337838614
+        value: 45.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 49.553773610098794
+        value: 49.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 26.997110444365234
+        value: 27.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 36.52478416449948
+        value: 36.52
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 52.3764911269869
+        value: 52.38
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 74.8548347678157
+        value: 74.85
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -131,31 +131,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 32.29775175733491
+        value: 32.3
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 34.765193183740536
+        value: 34.77
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 38.188602637927
+        value: 38.19
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 45.190455337838614
+        value: 45.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 49.553773610098794
+        value: 49.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 26.997110444365234
+        value: 27.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 36.52478416449948
+        value: 36.52
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 52.3764911269869
+        value: 52.38
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 74.8548347678157
+        value: 74.85
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -87,31 +87,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 36.568719499613124
+        value: 36.57
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 37.27309346927399
+        value: 37.27
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 33.635783466494495
+        value: 33.64
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.441716501928504
+        value: 43.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 36.28191671060777
+        value: 36.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 32.53017070680608
+        value: 32.53
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 25.570908880128044
+        value: 25.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 27.11224807526864
+        value: 27.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 29.023245584291217
+        value: 29.02
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -128,31 +128,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 36.568719499613124
+        value: 36.57
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 37.27309346927399
+        value: 37.27
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 33.635783466494495
+        value: 33.64
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.441716501928504
+        value: 43.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 36.28191671060777
+        value: 36.28
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 32.53017070680608
+        value: 32.53
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 25.570908880128044
+        value: 25.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 27.11224807526864
+        value: 27.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 29.023245584291217
+        value: 29.02
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO4.yaml
+++ b/config/zones/NO-NO4.yaml
@@ -80,31 +80,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 67.04206935014815
+        value: 67.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 58.555309136036634
+        value: 58.56
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 53.004485879099235
+        value: 53.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 55.97421650464496
+        value: 55.97
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 55.92418351333918
+        value: 55.92
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 47.94552948051728
+        value: 47.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 29.60671754549398
+        value: 29.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 43.748239544848715
+        value: 43.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 51.62607083363441
+        value: 51.63
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -121,31 +121,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 67.04206935014815
+        value: 67.04
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 58.555309136036634
+        value: 58.56
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 53.004485879099235
+        value: 53.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 55.97421650464496
+        value: 55.97
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 55.92418351333918
+        value: 55.92
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 47.94552948051728
+        value: 47.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 29.60671754549398
+        value: 29.61
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 43.748239544848715
+        value: 43.75
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 51.62607083363441
+        value: 51.63
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -80,31 +80,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 35.92616184895195
+        value: 35.93
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 37.04354207507762
+        value: 37.04
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 39.16227265310853
+        value: 39.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 40.36618981281962
+        value: 40.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 39.32116767627549
+        value: 39.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 35.407772780326646
+        value: 35.41
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 37.37350707720584
+        value: 37.37
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 31.398084262897072
+        value: 31.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.35924037474868
+        value: 27.36
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -121,31 +121,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 35.92616184895195
+        value: 35.93
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 37.04354207507762
+        value: 37.04
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 39.16227265310853
+        value: 39.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 40.36618981281962
+        value: 40.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 39.32116767627549
+        value: 39.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 35.407772780326646
+        value: 35.41
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 37.37350707720584
+        value: 37.37
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 31.398084262897072
+        value: 31.4
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.35924037474868
+        value: 27.36
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -72,31 +72,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 38.12675448490005
+        value: 38.13
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 38.145656791355584
+        value: 38.15
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 38.28693284279687
+        value: 38.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.58856437991398
+        value: 43.59
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 42.883159079717366
+        value: 42.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 32.79432163475604
+        value: 32.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 32.22358469511543
+        value: 32.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 37.87397964360943
+        value: 37.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 34.960641342654064
+        value: 34.96
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -113,31 +113,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 38.12675448490005
+        value: 38.13
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 38.145656791355584
+        value: 38.15
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 38.28693284279687
+        value: 38.29
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 43.58856437991398
+        value: 43.59
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 42.883159079717366
+        value: 42.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 32.79432163475604
+        value: 32.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 32.22358469511543
+        value: 32.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 37.87397964360943
+        value: 37.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 34.960641342654064
+        value: 34.96
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -112,25 +112,25 @@ emissionFactors:
         value: 107.38125000000001
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 100.26833784943321
+        value: 100.27
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 138.20739076099082
+        value: 138.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.16617260149694
+        value: 107.17
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -140,25 +140,25 @@ emissionFactors:
         value: 107.38125000000001
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 100.26833784943321
+        value: 100.27
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 100.26834031472883
+        value: 100.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 138.20739076099082
+        value: 138.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 107.16617260149694
+        value: 107.17
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -51,14 +51,14 @@ emissionFactors:
         value: 700.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 471.2454389226244
+        value: 471.25
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
         value: 700.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 471.2454389226244
+        value: 471.25
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average

--- a/config/zones/PA.yaml
+++ b/config/zones/PA.yaml
@@ -116,25 +116,25 @@ emissionFactors:
         value: 317.9022673053375
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 246.85848824622104
+        value: 246.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 173.6653862121206
+        value: 173.67
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 381.4426516411954
+        value: 381.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 264.73031796819595
+        value: 264.73
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 228.62491852255724
+        value: 228.62
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 237.64253482950627
+        value: 237.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 301.57686981494567
+        value: 301.58
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -144,25 +144,25 @@ emissionFactors:
         value: 317.9022673053375
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 246.85848824622104
+        value: 246.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 173.6653862121206
+        value: 173.67
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 381.4426516411954
+        value: 381.44
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 264.73031796819595
+        value: 264.73
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 228.62491852255724
+        value: 228.62
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 237.64253482950627
+        value: 237.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 301.57686981494567
+        value: 301.58
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/PE.yaml
+++ b/config/zones/PE.yaml
@@ -106,25 +106,25 @@ emissionFactors:
         value: 184.10742833453165
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 191.38462025918471
+        value: 191.38
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 173.577154760926
+        value: 173.58
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 181.47945540245607
+        value: 181.48
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 169.81431567596553
+        value: 169.81
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.93756740104226
+        value: 183.94
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 192.78221589200808
+        value: 192.78
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 218.58335364174238
+        value: 218.58
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -134,25 +134,25 @@ emissionFactors:
         value: 184.10742833453165
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 191.38462025918471
+        value: 191.38
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 173.577154760926
+        value: 173.58
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 181.47945540245607
+        value: 181.48
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 169.81431567596553
+        value: 169.81
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 183.93756740104226
+        value: 183.94
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 192.78221589200808
+        value: 192.78
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 218.58335364174238
+        value: 218.58
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/PF.yaml
+++ b/config/zones/PF.yaml
@@ -65,23 +65,23 @@ emissionFactors:
     battery discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 439.50962905975496
+        value: 439.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 355.92228020933777
+        value: 355.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 420.62566583541593
+        value: 420.63
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 439.50962905975496
+        value: 439.51
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 355.92228020933777
+        value: 355.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 420.62566583541593
+        value: 420.63
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2021 average

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -30,47 +30,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 660.9348695343014
+        value: 660.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 660.9414762641075
+        value: 660.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 660.9386200254985
+        value: 660.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 660.9357834886688
+        value: 660.94
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 660.9385711228483
+        value: 660.94
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 660.9385711228483
+        value: 660.94
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 642.5069130548749
+        value: 642.51
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 660.9348695343014
+        value: 660.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 660.9414762641075
+        value: 660.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 660.9386200254985
+        value: 660.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 660.9357834886688
+        value: 660.94
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 660.9385711228483
+        value: 660.94
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 660.9385711228483
+        value: 660.94
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 642.5069130548749
+        value: 642.51
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -28,47 +28,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 520.7886926862809
+        value: 520.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 501.2901455256027
+        value: 501.29
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 520.7886926862809
+        value: 520.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 520.7886777646738
+        value: 520.79
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 501.2901455256027
+        value: 501.29
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -29,47 +29,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 579.5653328872531
+        value: 579.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 602.4357088788341
+        value: 602.44
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 579.5653328872531
+        value: 579.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 579.5652748112943
+        value: 579.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 602.4357088788341
+        value: 602.44
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -23,47 +23,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 633.0309650444342
+        value: 633.03
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 633.0356638171361
+        value: 633.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 633.0335932008477
+        value: 633.03
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 633.031602032534
+        value: 633.03
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 633.0335895814336
+        value: 633.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 633.0335895814336
+        value: 633.03
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 617.5474885370581
+        value: 617.55
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 633.0309650444342
+        value: 633.03
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 633.0356638171361
+        value: 633.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 633.0335932008477
+        value: 633.03
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 633.031602032534
+        value: 633.03
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 633.0335895814336
+        value: 633.03
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 633.0335895814336
+        value: 633.03
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 617.5474885370581
+        value: 617.55
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -154,31 +154,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 940.2284594010355
+        value: 940.23
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 926.3151946595677
+        value: 926.32
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 909.0597066345614
+        value: 909.06
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 912.8750826790722
+        value: 912.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 872.5339224551733
+        value: 872.53
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 828.1429080788191
+        value: 828.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 856.6026318718095
+        value: 856.6
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 882.2789956835052
+        value: 882.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 793.618349176963
+        value: 793.62
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -212,31 +212,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 940.2284594010355
+        value: 940.23
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 926.3151946595677
+        value: 926.32
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 909.0597066345614
+        value: 909.06
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 912.8750826790722
+        value: 912.88
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 872.5339224551733
+        value: 872.53
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 828.1429080788191
+        value: 828.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 856.6026318718095
+        value: 856.6
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 882.2789956835052
+        value: 882.28
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 793.618349176963
+        value: 793.62
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/PR.yaml
+++ b/config/zones/PR.yaml
@@ -102,10 +102,10 @@ emissionFactors:
         value: 609.5049770315596
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 622.0627301219394
+        value: 622.06
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 606.5360250957143
+        value: 606.54
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -124,10 +124,10 @@ emissionFactors:
         value: 609.5049770315596
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 622.0627301219394
+        value: 622.06
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 606.5360250957143
+        value: 606.54
     unknown:
       _comment: 'Source: https://indicadores.pr/dataset/generacion-consumo-costo-ingresos-y-clientes-del-sistema-electrico-de-puerto-rico/resource/fdad4f42-a4be-48bb-9478-a8fb75c000c6'
       source: assumes 12% hydro, 57% solar, 31% wind based on average renewable generation

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -173,31 +173,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 400.3846424280469
+        value: 400.38
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 351.8097361748317
+        value: 351.81
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 406.8949723887363
+        value: 406.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 296.70138053326156
+        value: 296.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 211.11941799637268
+        value: 211.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 169.57041708682223
+        value: 169.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 139.1890770224589
+        value: 139.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 200.59878443295358
+        value: 200.6
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 127.10659966004847
+        value: 127.11
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -228,31 +228,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 400.3846424280469
+        value: 400.38
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 351.8097361748317
+        value: 351.81
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 406.8949723887363
+        value: 406.89
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 296.70138053326156
+        value: 296.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 211.11941799637268
+        value: 211.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 169.57041708682223
+        value: 169.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 139.1890770224589
+        value: 139.19
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 200.59878443295358
+        value: 200.6
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 127.10659966004847
+        value: 127.11
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/QA.yaml
+++ b/config/zones/QA.yaml
@@ -56,17 +56,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 470.00398411587173
+        value: 470.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 471.5096662734484
+        value: 471.51
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 470.00398411587173
+        value: 470.0
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 471.5096662734484
+        value: 471.51
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -39,102 +39,57 @@ emissionFactors:
         value: 398.8829700883609
   lifecycle:
     battery discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 404.8828990120726
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 517.3056328054994
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 520.1397655052556
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 268.3565336684562
+        value: 268.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 287.5443168099551
+        value: 287.54
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 253.10520828126354
+        value: 253.11
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 404.88
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 517.31
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 520.14
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 510.70049974042223
+        value: 510.7
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 530.7288818539226
+        value: 530.73
     hydro discharge:
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 404.8828990120726
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 517.3056328054994
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 520.1397655052556
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 268.3565336684562
+        value: 268.36
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 287.5443168099551
+        value: 287.54
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 253.10520828126354
+        value: 253.11
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 404.88
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 517.31
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 520.14
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 510.70049974042223
+        value: 510.7
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 530.7288818539226
+        value: 530.73
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0859186455260277
-        coal: 0.1462839720269014
-        gas: 0.30449600125458054
-        geothermal: 0.0
-        hydro: 0.18773551658133647
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.15789045757920134
-        solar: 0.11221847673266214
-        unknown: 0.0
-        wind: 0.005457035402375885
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0573605554696287
-        coal: 0.3298914414325319
-        gas: 0.1260505336965511
-        geothermal: 0.0
-        hydro: 0.16009704545773817
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.23994995609810063
-        solar: 0.0818280278419744
-        unknown: 0.0
-        wind: 0.004822394574461891
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.07244806657826934
-        coal: 0.2876557932915034
-        gas: 0.10735120698421882
-        geothermal: 0.0
-        hydro: 0.1396053191576842
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.30910372106431394
-        solar: 0.082156022159244
-        unknown: 0.0
-        wind: 0.0016797036868118804
     - _source: Electricity Maps, 2016 average
       datetime: '2016-01-01'
       value:
@@ -180,6 +135,51 @@ fallbackZoneMixes:
         solar: 0.14977818908728702
         unknown: 0.0
         wind: 0.0075428385416383545
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0859186455260277
+        coal: 0.1462839720269014
+        gas: 0.30449600125458054
+        geothermal: 0.0
+        hydro: 0.18773551658133647
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.15789045757920134
+        solar: 0.11221847673266214
+        unknown: 0.0
+        wind: 0.005457035402375885
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0573605554696287
+        coal: 0.3298914414325319
+        gas: 0.1260505336965511
+        geothermal: 0.0
+        hydro: 0.16009704545773817
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.23994995609810063
+        solar: 0.0818280278419744
+        unknown: 0.0
+        wind: 0.004822394574461891
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.07244806657826934
+        coal: 0.2876557932915034
+        gas: 0.10735120698421882
+        geothermal: 0.0
+        hydro: 0.1396053191576842
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.30910372106431394
+        solar: 0.082156022159244
+        unknown: 0.0
+        wind: 0.0016797036868118804
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -138,31 +138,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 480.4709874703865
+        value: 480.47
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 462.0574161758267
+        value: 462.06
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 486.10021950668187
+        value: 486.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 456.22604459618157
+        value: 456.23
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 429.1223709392727
+        value: 429.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 371.9867208655448
+        value: 371.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 390.8974871483404
+        value: 390.9
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 371.55025518667424
+        value: 371.55
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 297.6523881380711
+        value: 297.65
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -196,31 +196,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 480.4709874703865
+        value: 480.47
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 462.0574161758267
+        value: 462.06
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 486.10021950668187
+        value: 486.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 456.22604459618157
+        value: 456.23
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 429.1223709392727
+        value: 429.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 371.9867208655448
+        value: 371.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 390.8974871483404
+        value: 390.9
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 371.55025518667424
+        value: 371.55
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 297.6523881380711
+        value: 297.65
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -92,25 +92,25 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 581.1024159618794
+        value: 581.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 486.7232670295646
+        value: 486.72
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 455.9095124282983
+        value: 455.91
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 572.2426643875989
+        value: 572.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 528.8858703250975
+        value: 528.89
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 549.5274451439471
+        value: 549.53
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 544.1536166267986
+        value: 544.15
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -118,25 +118,25 @@ emissionFactors:
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 581.1024159618794
+        value: 581.1
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 486.7232670295646
+        value: 486.72
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 455.9095124282983
+        value: 455.91
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 572.2426643875989
+        value: 572.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 528.8858703250975
+        value: 528.89
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 549.5274451439471
+        value: 549.53
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 544.1536166267986
+        value: 544.15
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/RU-1.yaml
+++ b/config/zones/RU-1.yaml
@@ -44,49 +44,49 @@ emissionFactors:
         value: 391.0229938122812
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 355.15878947979013
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 356.0090224868252
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 346.60390311889955
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 356.8826444442073
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 354.71809337831513
+        value: 354.72
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 355.16
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 356.01
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 346.6
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 356.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 348.5905456753058
+        value: 348.59
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 353.6245017994455
+        value: 353.62
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 355.15878947979013
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 356.0090224868252
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 346.60390311889955
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 356.8826444442073
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 354.71809337831513
+        value: 354.72
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 355.16
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 356.01
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 346.6
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 356.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 348.5905456753058
+        value: 348.59
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 353.6245017994455
+        value: 353.62
     unknown:
       _comment: 'Assumes weighted average emission factor based on estimated 2021
         fuel consumption: 6.7% * 820 g/kWh (coal) + 0.5% * 650 g/kWh (oil) + 89.0%
@@ -97,6 +97,21 @@ emissionFactors:
       value: 517
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.00015497105348905135
+        coal: 0.001563593025619832
+        gas: 9.67719940588637e-05
+        geothermal: 0.0
+        hydro: 0.06945052846017895
+        hydro discharge: 2.0499828186950938e-08
+        nuclear: 0.2529369639617341
+        oil: 1.4595594424505447e-06
+        solar: 0.0016654782338762415
+        unknown: 0.6739663548749684
+        wind: 0.00016384952081551887
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -157,21 +172,6 @@ fallbackZoneMixes:
         solar: 0.001846085333379031
         unknown: 0.6756844817928821
         wind: 0.00026525193392446325
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.00015497105348905135
-        coal: 0.001563593025619832
-        gas: 9.67719940588637e-05
-        geothermal: 0.0
-        hydro: 0.06945052846017895
-        hydro discharge: 2.0499828186950938e-08
-        nuclear: 0.2529369639617341
-        oil: 1.4595594424505447e-06
-        solar: 0.0016654782338762415
-        unknown: 0.6739663548749684
-        wind: 0.00016384952081551887
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/RU-2.yaml
+++ b/config/zones/RU-2.yaml
@@ -43,41 +43,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 368.1214916165261
+        value: 368.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.4464383573389
+        value: 414.45
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 491.27720893672125
+        value: 491.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 452.40438728305634
+        value: 452.4
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 417.15906993581393
+        value: 417.16
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 398.89453466726457
+        value: 398.89
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 368.1214916165261
+        value: 368.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 414.4464383573389
+        value: 414.45
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 491.27720893672125
+        value: 491.28
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 452.40438728305634
+        value: 452.4
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 417.15906993581393
+        value: 417.16
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 398.89453466726457
+        value: 398.89
     unknown:
       _comment: 'Assumes weighted average emission factor based on estimated 2021
         fuel consumption: 86.0% * 820 g/kWh (coal) + 0.3% * 650 g/kWh (oil) + 9.1%

--- a/config/zones/RU-AS.yaml
+++ b/config/zones/RU-AS.yaml
@@ -20,23 +20,23 @@ emissionFactors:
     battery discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 381.2529749255522
+        value: 381.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.2731507282518
+        value: 405.27
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 433.34328502165005
+        value: 433.34
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 381.2529749255522
+        value: 381.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.2731507282518
+        value: 405.27
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 433.34328502165005
+        value: 433.34
     unknown:
       _comment: 'Assumes weighted average emission factor based on estimated 2021
         fuel consumption: 59.6% * 820 g/kWh (coal) + 0.3% * 650 g/kWh (oil) + 40.1%

--- a/config/zones/RU.yaml
+++ b/config/zones/RU.yaml
@@ -88,41 +88,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 364.3432458805215
+        value: 364.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 369.3563057578955
+        value: 369.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 376.7854735544027
+        value: 376.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 374.35549344091123
+        value: 374.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 364.8351539235969
+        value: 364.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 361.60051593042255
+        value: 361.6
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 364.3432458805215
+        value: 364.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 369.3563057578955
+        value: 369.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 376.7854735544027
+        value: 376.79
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 374.35549344091123
+        value: 374.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 364.8351539235969
+        value: 364.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 361.60051593042255
+        value: 361.6
     unknown:
       _comment: 'Assumes weighted average emission factor based on 2015-TWh production:
         22.7% * 820 g/kWh (coal) + 1.4% * 650 g/kWh (oil) + 75.8% * 490 g/kWh (gas)  =

--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -60,25 +60,25 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 17.83454402073228
+        value: 17.83
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 18.427472541944535
+        value: 18.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 17.36073998756103
+        value: 17.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 15.362770977612175
+        value: 15.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 14.270549026423087
+        value: 14.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 15.919525455407419
+        value: 15.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 16.327450764075646
+        value: 16.33
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -109,25 +109,25 @@ emissionFactors:
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 17.83454402073228
+        value: 17.83
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 18.427472541944535
+        value: 18.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 17.36073998756103
+        value: 17.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 15.362770977612175
+        value: 15.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 14.270549026423087
+        value: 14.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 15.919525455407419
+        value: 15.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 16.327450764075646
+        value: 16.33
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -110,25 +110,25 @@ emissionFactors:
         value: 15.43673799343062
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 17.51344291289496
+        value: 17.51
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 17.56012706097111
+        value: 17.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 17.33264601520518
+        value: 17.33
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 17.146037405201724
+        value: 17.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 17.66978939149613
+        value: 17.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 16.649477268582288
+        value: 16.65
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 17.362869252032045
+        value: 17.36
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -165,25 +165,25 @@ emissionFactors:
         value: 15.43673799343062
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 17.51344291289496
+        value: 17.51
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 17.56012706097111
+        value: 17.56
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 17.33264601520518
+        value: 17.33
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 17.146037405201724
+        value: 17.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 17.66978939149613
+        value: 17.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 16.649477268582288
+        value: 16.65
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 17.362869252032045
+        value: 17.36
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -110,25 +110,25 @@ emissionFactors:
         value: 28.504553460881134
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 26.741676732936035
+        value: 26.74
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 28.23821896214275
+        value: 28.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 26.497695257100595
+        value: 26.5
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.56787260618212
+        value: 24.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.114755823633267
+        value: 31.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 24.962778457646223
+        value: 24.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 23.400139329653108
+        value: 23.4
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -165,25 +165,25 @@ emissionFactors:
         value: 28.504553460881134
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 26.741676732936035
+        value: 26.74
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 28.23821896214275
+        value: 28.24
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 26.497695257100595
+        value: 26.5
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.56787260618212
+        value: 24.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.114755823633267
+        value: 31.11
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 24.962778457646223
+        value: 24.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 23.400139329653108
+        value: 23.4
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -110,25 +110,25 @@ emissionFactors:
         value: 61.501809138964035
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 46.9738803028632
+        value: 46.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 65.02161304196707
+        value: 65.02
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 79.57312590957217
+        value: 79.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 40.55802189654889
+        value: 40.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 59.66985158843888
+        value: 59.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 40.45039247352733
+        value: 40.45
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 41.403015441495256
+        value: 41.4
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -165,25 +165,25 @@ emissionFactors:
         value: 61.501809138964035
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 46.9738803028632
+        value: 46.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 65.02161304196707
+        value: 65.02
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 79.57312590957217
+        value: 79.57
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 40.55802189654889
+        value: 40.56
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 59.66985158843888
+        value: 59.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 40.45039247352733
+        value: 40.45
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 41.403015441495256
+        value: 41.4
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SE.yaml
+++ b/config/zones/SE.yaml
@@ -154,25 +154,25 @@ emissionFactors:
         value: 55.5151467459363
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 27.96923491907476
+        value: 27.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 31.84764619317954
+        value: 31.85
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 33.730319719845845
+        value: 33.73
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.833057430183658
+        value: 24.83
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.73888763178623
+        value: 31.74
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 25.820327244390995
+        value: 25.82
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 25.012621912694588
+        value: 25.01
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -209,25 +209,25 @@ emissionFactors:
         value: 55.5151467459363
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 27.96923491907476
+        value: 27.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 31.84764619317954
+        value: 31.85
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 33.730319719845845
+        value: 33.73
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.833057430183658
+        value: 24.83
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 31.73888763178623
+        value: 31.74
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 25.820327244390995
+        value: 25.82
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 25.012621912694588
+        value: 25.01
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SG.yaml
+++ b/config/zones/SG.yaml
@@ -107,25 +107,25 @@ emissionFactors:
         value: 491.5793609192606
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 492.0126850380795
+        value: 492.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 493.96635616122865
+        value: 493.97
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 493.31172271211005
+        value: 493.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 492.3133816577721
+        value: 492.31
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 491.3533112538693
+        value: 491.35
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 491.0947232991329
+        value: 491.09
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 487.5206153467702
+        value: 487.52
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -135,25 +135,25 @@ emissionFactors:
         value: 491.5793609192606
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 492.0126850380795
+        value: 492.01
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 493.96635616122865
+        value: 493.97
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 493.31172271211005
+        value: 493.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 492.3133816577721
+        value: 492.31
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 491.3533112538693
+        value: 491.35
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 491.0947232991329
+        value: 491.09
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 487.5206153467702
+        value: 487.52
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -145,31 +145,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 329.8638631395498
+        value: 329.86
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 322.0048383683077
+        value: 322.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 311.15504736655794
+        value: 311.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 309.5353483464321
+        value: 309.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 308.9515195536055
+        value: 308.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 223.29548422158618
+        value: 223.3
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 313.9131106700154
+        value: 313.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 324.89980738362755
+        value: 324.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 289.57333333333327
+        value: 289.57
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -203,31 +203,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 329.8638631395498
+        value: 329.86
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 322.0048383683077
+        value: 322.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 311.15504736655794
+        value: 311.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 309.5353483464321
+        value: 309.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 308.9515195536055
+        value: 308.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 223.29548422158618
+        value: 223.3
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 313.9131106700154
+        value: 313.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 324.89980738362755
+        value: 324.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 289.57333333333327
+        value: 289.57
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -104,31 +104,31 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 402.0661083409642
+        value: 402.07
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 388.9056610909538
+        value: 388.91
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 404.7839145060065
+        value: 404.78
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 359.3698120274996
+        value: 359.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 326.1581173919242
+        value: 326.16
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 298.05180596015964
+        value: 298.05
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 342.4406247048419
+        value: 342.44
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 359.1166549575652
+        value: 359.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 239.06002246243287
+        value: 239.06
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -162,31 +162,31 @@ emissionFactors:
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 402.0661083409642
+        value: 402.07
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 388.9056610909538
+        value: 388.91
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 404.7839145060065
+        value: 404.78
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 359.3698120274996
+        value: 359.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 326.1581173919242
+        value: 326.16
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 298.05180596015964
+        value: 298.05
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 342.4406247048419
+        value: 342.44
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 359.1166549575652
+        value: 359.12
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 239.06002246243287
+        value: 239.06
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SV.yaml
+++ b/config/zones/SV.yaml
@@ -108,47 +108,47 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 166.9416560484721
+        value: 166.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 185.8403843444717
+        value: 185.84
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 254.09976545310286
+        value: 254.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 183.09821399427364
+        value: 183.1
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 185.8774458393478
+        value: 185.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 206.46846657417873
+        value: 206.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 307.4592289563242
+        value: 307.46
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 166.9416560484721
+        value: 166.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 185.8403843444717
+        value: 185.84
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 254.09976545310286
+        value: 254.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 183.09821399427364
+        value: 183.1
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 185.8774458393478
+        value: 185.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 206.46846657417873
+        value: 206.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 307.4592289563242
+        value: 307.46
     unknown:
       _comment: Based on on 2022 generation from Our World in Data and IPCC 2014 emission
         factors

--- a/config/zones/TH.yaml
+++ b/config/zones/TH.yaml
@@ -57,17 +57,17 @@ emissionFactors:
     battery discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 409.0798286308625
+        value: 409.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 409.08054040481835
+        value: 409.08
     hydro discharge:
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 409.0798286308625
+        value: 409.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 409.08054040481835
+        value: 409.08
     unknown:
       - _comment: Gross Energy Generation of EGAT and Net Energy Generation of IPP,
           SPP, and VSPP

--- a/config/zones/TR.yaml
+++ b/config/zones/TR.yaml
@@ -120,59 +120,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 441.4848079678297
+        value: 441.48
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 452.7224279021227
+        value: 452.72
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 468.6402452827099
+        value: 468.64
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 476.35177838944986
+        value: 476.35
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 425.8940211079905
+        value: 425.89
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 427.01287665607833
+        value: 427.01
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 448.2729430654957
+        value: 448.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 430.86912731299134
+        value: 430.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 437.3632580015329
+        value: 437.36
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 441.4848079678297
+        value: 441.48
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 452.7224279021227
+        value: 452.72
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 468.6402452827099
+        value: 468.64
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 476.35177838944986
+        value: 476.35
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 425.8940211079905
+        value: 425.89
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 427.01287665607833
+        value: 427.01
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 448.2729430654957
+        value: 448.27
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 430.86912731299134
+        value: 430.87
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 437.3632580015329
+        value: 437.36
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -127,25 +127,25 @@ emissionFactors:
         value: 558.8386298157064
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 572.545690843018
+        value: 572.55
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 568.441191210358
+        value: 568.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 547.505186103948
+        value: 547.51
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 550.3483463706275
+        value: 550.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 548.2024698311949
+        value: 548.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 543.1458908650868
+        value: 543.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 529.6391717601999
+        value: 529.64
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -155,25 +155,25 @@ emissionFactors:
         value: 558.8386298157064
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 572.545690843018
+        value: 572.55
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 568.441191210358
+        value: 568.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 547.505186103948
+        value: 547.51
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 550.3483463706275
+        value: 550.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 548.2024698311949
+        value: 548.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 543.1458908650868
+        value: 543.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 529.6391717601999
+        value: 529.64
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -58,41 +58,41 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 317.95113401320367
+        value: 317.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 297.1560911218882
+        value: 297.16
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 281.26404075658695
+        value: 281.26
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 269.66341627440664
+        value: 269.66
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 239.45273000513498
+        value: 239.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 231.02727413611913
+        value: 231.03
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 317.95113401320367
+        value: 317.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 297.1560911218882
+        value: 297.16
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 281.26404075658695
+        value: 281.26
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 269.66341627440664
+        value: 269.66
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 239.45273000513498
+        value: 239.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 231.02727413611913
+        value: 231.03
     unknown:
       _comment: estimated yearly share of solar & wind in this mixed renewable category
         based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable
@@ -102,36 +102,6 @@ emissionFactors:
       value: 28
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0007413545317725314
-        coal: 0.26858328044141866
-        gas: 0.10042520555523944
-        geothermal: 3.173143541659477e-07
-        hydro: 0.053622959040597315
-        hydro discharge: 0.0002378366403909789
-        nuclear: 0.5187927239060157
-        oil: 0.00024380533001735718
-        solar: 0.000441857772383722
-        unknown: 0.056118076001992194
-        wind: 0.000792580300771159
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.000400733485935681
-        coal: 0.23791046801653395
-        gas: 0.06649976041599442
-        geothermal: 6.034217755345414e-08
-        hydro: 0.06827775603424625
-        hydro discharge: 0.00014737864965336445
-        nuclear: 0.5554740079691397
-        oil: 0.000138260472023641
-        solar: 0.00027980552471197536
-        unknown: 0.07014872959168042
-        wind: 0.00072303854870015
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -177,6 +147,36 @@ fallbackZoneMixes:
         solar: 0.00037996382318991807
         unknown: 0.02870293147427341
         wind: 0.004675357960815091
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0007413545317725314
+        coal: 0.26858328044141866
+        gas: 0.10042520555523944
+        geothermal: 3.173143541659477e-07
+        hydro: 0.053622959040597315
+        hydro discharge: 0.0002378366403909789
+        nuclear: 0.5187927239060157
+        oil: 0.00024380533001735718
+        solar: 0.000441857772383722
+        unknown: 0.056118076001992194
+        wind: 0.000792580300771159
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.000400733485935681
+        coal: 0.23791046801653395
+        gas: 0.06649976041599442
+        geothermal: 6.034217755345414e-08
+        hydro: 0.06827775603424625
+        hydro discharge: 0.00014737864965336445
+        nuclear: 0.5554740079691397
+        oil: 0.000138260472023641
+        solar: 0.00027980552471197536
+        unknown: 0.07014872959168042
+        wind: 0.00072303854870015
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -133,25 +133,25 @@ emissionFactors:
         value: 324.9658297422203
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 310.42246043173685
+        value: 310.42
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 268.9171641493862
+        value: 268.92
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 224.02465898754312
+        value: 224.02
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 238.23899185121402
+        value: 238.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 280.8223410395749
+        value: 280.82
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 253.4464055965425
+        value: 253.45
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 267.0526558050859
+        value: 267.05
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -172,25 +172,25 @@ emissionFactors:
         value: 324.9658297422203
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 310.42246043173685
+        value: 310.42
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 268.9171641493862
+        value: 268.92
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 224.02465898754312
+        value: 224.02
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 238.23899185121402
+        value: 238.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 280.8223410395749
+        value: 280.82
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 253.4464055965425
+        value: 253.45
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 267.0526558050859
+        value: 267.05
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -241,25 +241,25 @@ emissionFactors:
         value: 203.60146973413987
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 240.90059747323747
+        value: 240.9
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 283.54415474857905
+        value: 283.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 241.1727230838042
+        value: 241.17
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 271.20094584213695
+        value: 271.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 238.32169139820004
+        value: 238.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 224.05494558765844
+        value: 224.05
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 212.60826332277733
+        value: 212.61
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -299,25 +299,25 @@ emissionFactors:
         value: 203.60146973413987
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 240.90059747323747
+        value: 240.9
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 283.54415474857905
+        value: 283.54
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 241.1727230838042
+        value: 241.17
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 271.20094584213695
+        value: 271.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 238.32169139820004
+        value: 238.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 224.05494558765844
+        value: 224.05
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 212.60826332277733
+        value: 212.61
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -150,25 +150,25 @@ emissionFactors:
         value: 583.9688111407905
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 566.9467240919615
+        value: 566.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 615.955812773777
+        value: 615.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 609.184640949804
+        value: 609.18
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 608.5954786994934
+        value: 608.6
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 607.3194306574558
+        value: 607.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 523.6612579544013
+        value: 523.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 525.0227861835928
+        value: 525.02
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -203,25 +203,25 @@ emissionFactors:
         value: 583.9688111407905
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 566.9467240919615
+        value: 566.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 615.955812773777
+        value: 615.96
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 609.184640949804
+        value: 609.18
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 608.5954786994934
+        value: 608.6
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 607.3194306574558
+        value: 607.32
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 523.6612579544013
+        value: 523.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 525.0227861835928
+        value: 525.02
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -150,25 +150,25 @@ emissionFactors:
         value: 575.2061680296513
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 489.7707180536442
+        value: 489.77
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 509.4304582413093
+        value: 509.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 474.1359232175503
+        value: 474.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 462.99389655172416
+        value: 462.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 366.392752553916
+        value: 366.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 356.2445988661387
+        value: 356.24
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.8749552734103
+        value: 377.87
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -199,25 +199,25 @@ emissionFactors:
         value: 575.2061680296513
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 489.7707180536442
+        value: 489.77
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 509.4304582413093
+        value: 509.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 474.1359232175503
+        value: 474.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 462.99389655172416
+        value: 462.99
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 366.392752553916
+        value: 366.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 356.2445988661387
+        value: 356.24
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 377.8749552734103
+        value: 377.87
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -130,25 +130,25 @@ emissionFactors:
         value: 499.11497719780664
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 392.0441581713828
+        value: 392.04
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 385.18628864498066
+        value: 385.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 326.9775365064599
+        value: 326.98
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 357.70167746492365
+        value: 357.7
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 387.4225098475262
+        value: 387.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 389.66516276313666
+        value: 389.67
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 380.91878252443746
+        value: 380.92
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -169,25 +169,25 @@ emissionFactors:
         value: 499.11497719780664
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 392.0441581713828
+        value: 392.04
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 385.18628864498066
+        value: 385.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 326.9775365064599
+        value: 326.98
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 357.70167746492365
+        value: 357.7
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 387.4225098475262
+        value: 387.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 389.66516276313666
+        value: 389.67
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 380.91878252443746
+        value: 380.92
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -162,22 +162,22 @@ emissionFactors:
         value: 325.45596089160216
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 319.8292554918968
+        value: 319.83
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 363.54941370865276
+        value: 363.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 357.16719464568473
+        value: 357.17
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 315.32829304603325
+        value: 315.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 326.2433716770591
+        value: 326.24
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 297.28681446907814
+        value: 297.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
         value: 284.92
@@ -213,22 +213,22 @@ emissionFactors:
         value: 325.45596089160216
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 319.8292554918968
+        value: 319.83
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 363.54941370865276
+        value: 363.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 357.16719464568473
+        value: 357.17
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 315.32829304603325
+        value: 315.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 326.2433716770591
+        value: 326.24
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 297.28681446907814
+        value: 297.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
         value: 284.92

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -128,25 +128,25 @@ emissionFactors:
         value: 520.3362123801293
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 457.64567228661747
+        value: 457.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 470.62512466654806
+        value: 470.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 407.0335502327385
+        value: 407.03
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 383.17317666126416
+        value: 383.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.4520898437501
+        value: 520.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 496.68713261648753
+        value: 496.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 545.4644012605042
+        value: 545.46
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -165,25 +165,25 @@ emissionFactors:
         value: 520.3362123801293
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 457.64567228661747
+        value: 457.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 470.62512466654806
+        value: 470.63
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 407.0335502327385
+        value: 407.03
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 383.17317666126416
+        value: 383.17
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 520.4520898437501
+        value: 520.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 496.68713261648753
+        value: 496.69
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 545.4644012605042
+        value: 545.46
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -155,10 +155,10 @@ emissionFactors:
         value: 292.85124834814974
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 318.8611492644335
+        value: 318.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 341.3380680492271
+        value: 341.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 326.88
@@ -167,13 +167,13 @@ emissionFactors:
         value: 324.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 295.9996924534215
+        value: 296.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 287.2553974599996
+        value: 287.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 277.97916337029017
+        value: 277.98
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -199,10 +199,10 @@ emissionFactors:
         value: 292.85124834814974
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 318.8611492644335
+        value: 318.86
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 341.3380680492271
+        value: 341.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 326.88
@@ -211,13 +211,13 @@ emissionFactors:
         value: 324.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 295.9996924534215
+        value: 296.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 287.2553974599996
+        value: 287.26
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 277.97916337029017
+        value: 277.98
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -146,25 +146,25 @@ emissionFactors:
         value: 783.3566963513733
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 669.2361753612311
+        value: 669.24
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 763.0302660540463
+        value: 763.03
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 600.881592920354
+        value: 600.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 613.3610293339605
+        value: 613.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 582.6716705336426
+        value: 582.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 606.0875172048703
+        value: 606.09
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 644.5754474337607
+        value: 644.58
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -197,25 +197,25 @@ emissionFactors:
         value: 783.3566963513733
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 669.2361753612311
+        value: 669.24
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 763.0302660540463
+        value: 763.03
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 600.881592920354
+        value: 600.88
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 613.3610293339605
+        value: 613.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 582.6716705336426
+        value: 582.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 606.0875172048703
+        value: 606.09
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 644.5754474337607
+        value: 644.58
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -156,25 +156,25 @@ emissionFactors:
         value: 450.76705463366125
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 445.8119293660269
+        value: 445.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 546.6508048924608
+        value: 546.65
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 467.1189111733266
+        value: 467.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 423.6110921998766
+        value: 423.61
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 474.6435365568433
+        value: 474.64
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 445.4698190210563
+        value: 445.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 452.3503192799216
+        value: 452.35
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -207,25 +207,25 @@ emissionFactors:
         value: 450.76705463366125
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 445.8119293660269
+        value: 445.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 546.6508048924608
+        value: 546.65
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 467.1189111733266
+        value: 467.12
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 423.6110921998766
+        value: 423.61
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 474.6435365568433
+        value: 474.64
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 445.4698190210563
+        value: 445.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 452.3503192799216
+        value: 452.35
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -118,25 +118,25 @@ emissionFactors:
         value: 23.999999999999996
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 29.094688782741454
+        value: 29.09
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 35.342862347123116
+        value: 35.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 49.46417517271918
+        value: 49.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 29.927986759319555
+        value: 29.93
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 55.76816375998948
+        value: 55.77
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 52.08174619143431
+        value: 52.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 50.29191827265855
+        value: 50.29
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -154,25 +154,25 @@ emissionFactors:
         value: 23.999999999999996
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 29.094688782741454
+        value: 29.09
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 35.342862347123116
+        value: 35.34
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 49.46417517271918
+        value: 49.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 29.927986759319555
+        value: 29.93
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 55.76816375998948
+        value: 55.77
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 52.08174619143431
+        value: 52.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 50.29191827265855
+        value: 50.29
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -133,25 +133,25 @@ emissionFactors:
         value: 175.34791543743
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 175.5905080399158
+        value: 175.59
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 295.46130044263276
+        value: 295.46
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 152.9352079939322
+        value: 152.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 178.70922204659345
+        value: 178.71
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 210.22717311133155
+        value: 210.23
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 222.95500799373872
+        value: 222.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 195.84691447673742
+        value: 195.85
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -172,25 +172,25 @@ emissionFactors:
         value: 175.34791543743
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 175.5905080399158
+        value: 175.59
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 295.46130044263276
+        value: 295.46
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 152.9352079939322
+        value: 152.94
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 178.70922204659345
+        value: 178.71
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 210.22717311133155
+        value: 210.23
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 222.95500799373872
+        value: 222.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 195.84691447673742
+        value: 195.85
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -219,25 +219,25 @@ emissionFactors:
         value: 528.845477679023
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 601.9466484248428
+        value: 601.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 584.986837801817
+        value: 584.99
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 517.8095666288424
+        value: 517.81
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 487.54321757559205
+        value: 487.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 491.38625863290383
+        value: 491.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 474.99073751858043
+        value: 474.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 443.3907230058154
+        value: 443.39
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -270,25 +270,25 @@ emissionFactors:
         value: 528.845477679023
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 601.9466484248428
+        value: 601.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 584.986837801817
+        value: 584.99
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 517.8095666288424
+        value: 517.81
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 487.54321757559205
+        value: 487.54
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 491.38625863290383
+        value: 491.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 474.99073751858043
+        value: 474.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 443.3907230058154
+        value: 443.39
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -141,25 +141,25 @@ emissionFactors:
         value: 609.5529341397407
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 601.0278025734317
+        value: 601.03
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 624.4116053915341
+        value: 624.41
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 601.0012183215678
+        value: 601.0
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 588.1280442384939
+        value: 588.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 586.3398721733806
+        value: 586.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 567.6172162935225
+        value: 567.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 548.6020883882436
+        value: 548.6
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -183,25 +183,25 @@ emissionFactors:
         value: 609.5529341397407
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 601.0278025734317
+        value: 601.03
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 624.4116053915341
+        value: 624.41
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 601.0012183215678
+        value: 601.0
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 588.1280442384939
+        value: 588.13
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 586.3398721733806
+        value: 586.34
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 567.6172162935225
+        value: 567.62
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 548.6020883882436
+        value: 548.6
     oil:
       - datetime: '2014-01-01'
         source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -166,25 +166,25 @@ emissionFactors:
         value: 539.9600938015636
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 532.7097876146822
+        value: 532.71
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.0355878171575
+        value: 561.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 545.5889928312264
+        value: 545.59
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 548.198397725898
+        value: 548.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 547.4855544284159
+        value: 547.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 534.8392063456279
+        value: 534.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 520.8292986680581
+        value: 520.83
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -215,25 +215,25 @@ emissionFactors:
         value: 539.9600938015636
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 532.7097876146822
+        value: 532.71
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 561.0355878171575
+        value: 561.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 545.5889928312264
+        value: 545.59
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 548.198397725898
+        value: 548.2
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 547.4855544284159
+        value: 547.49
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 534.8392063456279
+        value: 534.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 520.8292986680581
+        value: 520.83
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -153,25 +153,25 @@ emissionFactors:
         value: 387.86446506356134
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 388.6306029290955
+        value: 388.63
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 408.20268547660544
+        value: 408.2
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 413.1374784454141
+        value: 413.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 417.3479856024094
+        value: 417.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 401.6217728940244
+        value: 401.62
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 401.79873738887
+        value: 401.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 407.43189162554876
+        value: 407.43
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -199,25 +199,25 @@ emissionFactors:
         value: 387.86446506356134
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 388.6306029290955
+        value: 388.63
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 408.20268547660544
+        value: 408.2
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 413.1374784454141
+        value: 413.14
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 417.3479856024094
+        value: 417.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 401.6217728940244
+        value: 401.62
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 401.79873738887
+        value: 401.8
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 407.43189162554876
+        value: 407.43
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -141,25 +141,25 @@ emissionFactors:
         value: 719.738611134405
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 689.2768550612184
+        value: 689.28
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 671.250308147161
+        value: 671.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 707.4885437148532
+        value: 707.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 648.7674817939419
+        value: 648.77
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 706.8377504451126
+        value: 706.84
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 661.9647058147808
+        value: 661.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 577.250741213952
+        value: 577.25
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -192,25 +192,25 @@ emissionFactors:
         value: 719.738611134405
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 689.2768550612184
+        value: 689.28
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 671.250308147161
+        value: 671.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 707.4885437148532
+        value: 707.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 648.7674817939419
+        value: 648.77
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 706.8377504451126
+        value: 706.84
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 661.9647058147808
+        value: 661.96
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 577.250741213952
+        value: 577.25
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -74,25 +74,25 @@ emissionFactors:
     battery discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 490.00000000000006
+        value: 490.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 420.15070306481596
+        value: 420.15
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 413.68139906764037
+        value: 413.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 418.43199813462957
+        value: 418.43
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 402.38951809817286
+        value: 402.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 402.66694581555356
+        value: 402.67
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 408.89877285228727
+        value: 408.9
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -104,25 +104,25 @@ emissionFactors:
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 490.00000000000006
+        value: 490.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 420.15070306481596
+        value: 420.15
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 413.68139906764037
+        value: 413.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 418.43199813462957
+        value: 418.43
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 402.38951809817286
+        value: 402.39
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 402.66694581555356
+        value: 402.67
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 408.89877285228727
+        value: 408.9
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -133,25 +133,25 @@ emissionFactors:
         value: 790.412195248952
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 788.8088191888427
+        value: 788.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 688.19093524006
+        value: 688.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 647.7763075933578
+        value: 647.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 716.1476768812894
+        value: 716.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 638.4625137360705
+        value: 638.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 630.0127979306898
+        value: 630.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 627.1574973882684
+        value: 627.16
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -180,25 +180,25 @@ emissionFactors:
         value: 790.412195248952
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 788.8088191888427
+        value: 788.81
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 688.19093524006
+        value: 688.19
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 647.7763075933578
+        value: 647.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 716.1476768812894
+        value: 716.15
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 638.4625137360705
+        value: 638.46
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 630.0127979306898
+        value: 630.01
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 627.1574973882684
+        value: 627.16
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -137,25 +137,25 @@ emissionFactors:
         value: 514.3329608680659
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 770.3925058213644
+        value: 770.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 874.0886715535466
+        value: 874.09
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 823.0045423823238
+        value: 823.0
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 811.1366306809964
+        value: 811.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 792.9137282985741
+        value: 792.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 780.3231588624726
+        value: 780.32
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 662.4431251205059
+        value: 662.44
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -181,25 +181,25 @@ emissionFactors:
         value: 514.3329608680659
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 770.3925058213644
+        value: 770.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 874.0886715535466
+        value: 874.09
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 823.0045423823238
+        value: 823.0
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 811.1366306809964
+        value: 811.14
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 792.9137282985741
+        value: 792.91
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 780.3231588624726
+        value: 780.32
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 662.4431251205059
+        value: 662.44
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -127,25 +127,25 @@ emissionFactors:
         value: 463.9668381529327
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 464.0671152154101
+        value: 464.07
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 482.33459254306706
+        value: 482.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 476.57556108050596
+        value: 476.58
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 459.445210276834
+        value: 459.45
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 467.762351056982
+        value: 467.76
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.67910275693896
+        value: 465.68
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 464.1088179070777
+        value: 464.11
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -166,25 +166,25 @@ emissionFactors:
         value: 463.9668381529327
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 464.0671152154101
+        value: 464.07
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 482.33459254306706
+        value: 482.33
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 476.57556108050596
+        value: 476.58
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 459.445210276834
+        value: 459.45
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 467.762351056982
+        value: 467.76
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.67910275693896
+        value: 465.68
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 464.1088179070777
+        value: 464.11
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -145,25 +145,25 @@ emissionFactors:
         value: 595.4541895887378
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 584.1642118936297
+        value: 584.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 634.7746835336239
+        value: 634.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 603.6347767805239
+        value: 603.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 589.5676342543705
+        value: 589.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 565.5302980884977
+        value: 565.53
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 541.0804053357359
+        value: 541.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 512.7746925491305
+        value: 512.77
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -196,25 +196,25 @@ emissionFactors:
         value: 595.4541895887378
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 584.1642118936297
+        value: 584.16
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 634.7746835336239
+        value: 634.77
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 603.6347767805239
+        value: 603.63
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 589.5676342543705
+        value: 589.57
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 565.5302980884977
+        value: 565.53
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 541.0804053357359
+        value: 541.08
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 512.7746925491305
+        value: 512.77
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-HI-OA.yaml
+++ b/config/zones/US-HI-OA.yaml
@@ -106,16 +106,16 @@ emissionFactors:
         value: 968.2804597073409
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 971.0539097941493
+        value: 971.05
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 948.89598336777
+        value: 948.9
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 884.5554408810431
+        value: 884.56
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 879.0436137426954
+        value: 879.04
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -149,16 +149,16 @@ emissionFactors:
         value: 968.2804597073409
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 971.0539097941493
+        value: 971.05
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 948.89598336777
+        value: 948.9
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 884.5554408810431
+        value: 884.56
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 879.0436137426954
+        value: 879.04
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -243,25 +243,25 @@ emissionFactors:
         value: 438.08497262864455
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 443.9133695145501
+        value: 443.91
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 458.5483099654672
+        value: 458.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 454.19245799783613
+        value: 454.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 420.98265197431374
+        value: 420.98
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 441.45156932656795
+        value: 441.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 429.8444251949399
+        value: 429.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 394.89699236599625
+        value: 394.9
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -294,25 +294,25 @@ emissionFactors:
         value: 438.08497262864455
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 443.9133695145501
+        value: 443.91
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 458.5483099654672
+        value: 458.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 454.19245799783613
+        value: 454.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 420.98265197431374
+        value: 420.98
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 441.45156932656795
+        value: 441.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 429.8444251949399
+        value: 429.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 394.89699236599625
+        value: 394.9
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -144,25 +144,25 @@ emissionFactors:
         value: 759.4518396337845
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 718.5705007423758
+        value: 718.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 749.7109896251796
+        value: 749.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 711.7766553077454
+        value: 711.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 668.9600241776066
+        value: 668.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 663.2455830007161
+        value: 663.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 663.8471713145294
+        value: 663.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 619.2073765280536
+        value: 619.21
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -188,25 +188,25 @@ emissionFactors:
         value: 759.4518396337845
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 718.5705007423758
+        value: 718.57
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 749.7109896251796
+        value: 749.71
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 711.7766553077454
+        value: 711.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 668.9600241776066
+        value: 668.96
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 663.2455830007161
+        value: 663.25
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 663.8471713145294
+        value: 663.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 619.2073765280536
+        value: 619.21
     oil:
       - datetime: '2014-01-01'
         source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -137,25 +137,25 @@ emissionFactors:
         value: 949.4318865006369
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 902.3194856591009
+        value: 902.32
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 892.8338284781436
+        value: 892.83
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 887.3107165247635
+        value: 887.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 893.2364007185245
+        value: 893.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 890.6253995466361
+        value: 890.63
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 859.5727090457757
+        value: 859.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 863.0060592199835
+        value: 863.01
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -181,25 +181,25 @@ emissionFactors:
         value: 949.4318865006369
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 902.3194856591009
+        value: 902.32
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 892.8338284781436
+        value: 892.83
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 887.3107165247635
+        value: 887.31
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 893.2364007185245
+        value: 893.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 890.6253995466361
+        value: 890.63
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 859.5727090457757
+        value: 859.57
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 863.0060592199835
+        value: 863.01
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -268,25 +268,25 @@ emissionFactors:
         value: 608.5565899808616
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 580.9941691385237
+        value: 580.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 669.1606678908355
+        value: 669.16
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 581.1928477965287
+        value: 581.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 525.6840179351262
+        value: 525.68
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 561.934810136581
+        value: 561.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 526.1783393650632
+        value: 526.18
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 501.7587583654489
+        value: 501.76
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -319,25 +319,25 @@ emissionFactors:
         value: 608.5565899808616
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 580.9941691385237
+        value: 580.99
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 669.1606678908355
+        value: 669.16
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 581.1928477965287
+        value: 581.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 525.6840179351262
+        value: 525.68
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 561.934810136581
+        value: 561.93
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 526.1783393650632
+        value: 526.18
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 501.7587583654489
+        value: 501.76
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -225,25 +225,25 @@ emissionFactors:
         value: 345.4491038288679
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 320.4011165719547
+        value: 320.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 295.36627867831425
+        value: 295.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 258.05986401451236
+        value: 258.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 268.99860277437716
+        value: 269.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 272.8291734517805
+        value: 272.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 278.8418408208553
+        value: 278.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 285.7530776217137
+        value: 285.75
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -276,25 +276,25 @@ emissionFactors:
         value: 345.4491038288679
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 320.4011165719547
+        value: 320.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 295.36627867831425
+        value: 295.37
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 258.05986401451236
+        value: 258.06
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 268.99860277437716
+        value: 269.0
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 272.8291734517805
+        value: 272.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 278.8418408208553
+        value: 278.84
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 285.7530776217137
+        value: 285.75
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -134,25 +134,25 @@ emissionFactors:
         value: 229.9614089117601
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 230.93490616900638
+        value: 230.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 319.1154021087451
+        value: 319.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 228.63734258995507
+        value: 228.64
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 176.9510803016178
+        value: 176.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 198.29779265727592
+        value: 198.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 184.13058128827444
+        value: 184.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 240.29665890694727
+        value: 240.3
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -180,25 +180,25 @@ emissionFactors:
         value: 229.9614089117601
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 230.93490616900638
+        value: 230.93
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 319.1154021087451
+        value: 319.12
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 228.63734258995507
+        value: 228.64
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 176.9510803016178
+        value: 176.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 198.29779265727592
+        value: 198.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 184.13058128827444
+        value: 184.13
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 240.29665890694727
+        value: 240.3
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -162,25 +162,25 @@ emissionFactors:
         value: 67.71636960293682
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 67.96301513803883
+        value: 67.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 102.27636227042117
+        value: 102.28
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 118.0064261308647
+        value: 118.01
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 69.44179697044207
+        value: 69.44
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 90.77747893497093
+        value: 90.78
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 86.25250138619887
+        value: 86.25
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 122.79868652064246
+        value: 122.8
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -215,25 +215,25 @@ emissionFactors:
         value: 67.71636960293682
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 67.96301513803883
+        value: 67.96
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 102.27636227042117
+        value: 102.28
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 118.0064261308647
+        value: 118.01
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 69.44179697044207
+        value: 69.44
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 90.77747893497093
+        value: 90.78
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 86.25250138619887
+        value: 86.25
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 122.79868652064246
+        value: 122.8
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -123,25 +123,25 @@ emissionFactors:
         value: 23.969777262777868
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 23.97164268594793
+        value: 23.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 26.096588346978336
+        value: 26.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 26.4080142057155
+        value: 26.41
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.72230194753838
+        value: 24.72
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 25.421214309610097
+        value: 25.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 24.916722404522005
+        value: 24.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.60522353588342
+        value: 27.61
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -159,25 +159,25 @@ emissionFactors:
         value: 23.969777262777868
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 23.97164268594793
+        value: 23.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 26.096588346978336
+        value: 26.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 26.4080142057155
+        value: 26.41
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 24.72230194753838
+        value: 24.72
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 25.421214309610097
+        value: 25.42
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 24.916722404522005
+        value: 24.92
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 27.60522353588342
+        value: 27.61
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -120,25 +120,25 @@ emissionFactors:
         value: 24.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 23.999999999999996
+        value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 29.26528326073448
+        value: 29.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 31.53601732514308
+        value: 31.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 25.845695905243765
+        value: 25.85
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 27.382058226732237
+        value: 27.38
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 26.391855453766702
+        value: 26.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 32.26045995325346
+        value: 32.26
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -156,25 +156,25 @@ emissionFactors:
         value: 24.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 23.999999999999996
+        value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 29.26528326073448
+        value: 29.27
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 31.53601732514308
+        value: 31.54
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 25.845695905243765
+        value: 25.85
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 27.382058226732237
+        value: 27.38
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 26.391855453766702
+        value: 26.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 32.26045995325346
+        value: 32.26
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -123,22 +123,22 @@ emissionFactors:
         value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 47.03585555652582
+        value: 47.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 50.36352818965378
+        value: 50.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 39.1598382663306
+        value: 39.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 42.45124293885544
+        value: 42.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 37.55526214517685
+        value: 37.56
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 57.795787906898234
+        value: 57.8
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -159,22 +159,22 @@ emissionFactors:
         value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 47.03585555652582
+        value: 47.04
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 50.36352818965378
+        value: 50.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 39.1598382663306
+        value: 39.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 42.45124293885544
+        value: 42.45
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 37.55526214517685
+        value: 37.56
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 57.795787906898234
+        value: 57.8
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -127,25 +127,25 @@ emissionFactors:
         value: 518.9664865673914
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 515.9491115054512
+        value: 515.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 513.9818452633963
+        value: 513.98
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 513.4911825177915
+        value: 513.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 614.2409258115895
+        value: 614.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 490.749789510135
+        value: 490.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 503.3096753268804
+        value: 503.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 509.1745665310683
+        value: 509.17
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -166,25 +166,25 @@ emissionFactors:
         value: 518.9664865673914
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 515.9491115054512
+        value: 515.95
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 513.9818452633963
+        value: 513.98
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 513.4911825177915
+        value: 513.49
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 614.2409258115895
+        value: 614.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 490.749789510135
+        value: 490.75
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 503.3096753268804
+        value: 503.31
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 509.1745665310683
+        value: 509.17
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -146,25 +146,25 @@ emissionFactors:
         value: 144.28413545417715
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 150.39037066922901
+        value: 150.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 339.2945795325927
+        value: 339.29
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 317.36362305770115
+        value: 317.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 280.3822773751627
+        value: 280.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 365.701464129399
+        value: 365.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 356.44293685933087
+        value: 356.44
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 344.8909984452776
+        value: 344.89
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -192,25 +192,25 @@ emissionFactors:
         value: 144.28413545417715
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 150.39037066922901
+        value: 150.39
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 339.2945795325927
+        value: 339.29
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 317.36362305770115
+        value: 317.36
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 280.3822773751627
+        value: 280.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 365.701464129399
+        value: 365.7
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 356.44293685933087
+        value: 356.44
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 344.8909984452776
+        value: 344.89
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -177,25 +177,25 @@ emissionFactors:
         value: 548.7472906956419
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 520.1521666701932
+        value: 520.15
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 565.9069476055992
+        value: 565.91
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.7554882067665
+        value: 539.76
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 499.8135024036541
+        value: 499.81
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 497.1358657539373
+        value: 497.14
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 468.89214833810195
+        value: 468.89
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 456.17572322010153
+        value: 456.18
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -228,25 +228,25 @@ emissionFactors:
         value: 548.7472906956419
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 520.1521666701932
+        value: 520.15
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 565.9069476055992
+        value: 565.91
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 539.7554882067665
+        value: 539.76
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 499.8135024036541
+        value: 499.81
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 497.1358657539373
+        value: 497.14
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 468.89214833810195
+        value: 468.89
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 456.17572322010153
+        value: 456.18
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -155,25 +155,25 @@ emissionFactors:
         value: 753.8445692092185
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 718.4547129166144
+        value: 718.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 792.8417112497015
+        value: 792.84
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 744.6987340599204
+        value: 744.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 602.265559927788
+        value: 602.27
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 668.4079268678706
+        value: 668.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 660.6441288688932
+        value: 660.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 636.0912258165891
+        value: 636.09
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -199,25 +199,25 @@ emissionFactors:
         value: 753.8445692092185
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 718.4547129166144
+        value: 718.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 792.8417112497015
+        value: 792.84
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 744.6987340599204
+        value: 744.7
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 602.265559927788
+        value: 602.27
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 668.4079268678706
+        value: 668.41
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 660.6441288688932
+        value: 660.64
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 636.0912258165891
+        value: 636.09
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -185,25 +185,25 @@ emissionFactors:
         value: 725.8731688881752
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 708.70463212867
+        value: 708.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 754.8677692589355
+        value: 754.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 704.5464336041982
+        value: 704.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 676.066770446789
+        value: 676.07
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 634.1168775931457
+        value: 634.12
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 658.9025642140125
+        value: 658.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 741.4225
+        value: 741.42
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -236,25 +236,25 @@ emissionFactors:
         value: 725.8731688881752
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 708.70463212867
+        value: 708.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 754.8677692589355
+        value: 754.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 704.5464336041982
+        value: 704.55
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 676.066770446789
+        value: 676.07
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 634.1168775931457
+        value: 634.12
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 658.9025642140125
+        value: 658.9
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 741.4225
+        value: 741.42
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -146,25 +146,25 @@ emissionFactors:
         value: 508.42124818162455
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 525.6514360730594
+        value: 525.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 346.00993555378136
+        value: 346.01
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 360.61018554885766
+        value: 360.61
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 402.10999999999996
+        value: 402.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 334.87172335600906
+        value: 334.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 303.7683333333333
+        value: 303.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 269.50695652173914
+        value: 269.51
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -193,25 +193,25 @@ emissionFactors:
         value: 508.42124818162455
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 525.6514360730594
+        value: 525.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 346.00993555378136
+        value: 346.01
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 360.61018554885766
+        value: 360.61
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 402.10999999999996
+        value: 402.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 334.87172335600906
+        value: 334.87
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 303.7683333333333
+        value: 303.77
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 269.50695652173914
+        value: 269.51
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -134,25 +134,25 @@ emissionFactors:
         value: 418.84067817607627
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 427.6492462456607
+        value: 427.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 214.9418334022392
+        value: 214.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 213.9262598295396
+        value: 213.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 162.67157716008535
+        value: 162.67
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 199.1625591753572
+        value: 199.16
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 174.21178376917598
+        value: 174.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 239.12402026410462
+        value: 239.12
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -173,25 +173,25 @@ emissionFactors:
         value: 418.84067817607627
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 427.6492462456607
+        value: 427.65
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 214.9418334022392
+        value: 214.94
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 213.9262598295396
+        value: 213.93
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 162.67157716008535
+        value: 162.67
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 199.1625591753572
+        value: 199.16
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 174.21178376917598
+        value: 174.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 239.12402026410462
+        value: 239.12
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -161,25 +161,25 @@ emissionFactors:
         value: 625.0950186423416
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 594.9716802140134
+        value: 594.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 768.776385965169
+        value: 768.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 710.7750754028888
+        value: 710.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 606.8645335361812
+        value: 606.86
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 599.962568860749
+        value: 599.96
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 547.2240674270296
+        value: 547.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 511.427508826357
+        value: 511.43
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -205,25 +205,25 @@ emissionFactors:
         value: 625.0950186423416
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 594.9716802140134
+        value: 594.97
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 768.776385965169
+        value: 768.78
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 710.7750754028888
+        value: 710.78
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 606.8645335361812
+        value: 606.86
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 599.962568860749
+        value: 599.96
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 547.2240674270296
+        value: 547.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 511.427508826357
+        value: 511.43
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -153,25 +153,25 @@ emissionFactors:
         value: 385.2979118018555
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 374.44926927232746
+        value: 374.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 250.8349558966594
+        value: 250.83
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 255.42424180773085
+        value: 255.42
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 183.12271996398496
+        value: 183.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 148.67387770095797
+        value: 148.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 133.24782347675801
+        value: 133.25
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 190.2919967265502
+        value: 190.29
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -199,25 +199,25 @@ emissionFactors:
         value: 385.2979118018555
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 374.44926927232746
+        value: 374.45
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 250.8349558966594
+        value: 250.83
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 255.42424180773085
+        value: 255.42
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 183.12271996398496
+        value: 183.12
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 148.67387770095797
+        value: 148.67
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 133.24782347675801
+        value: 133.25
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 190.2919967265502
+        value: 190.29
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -129,7 +129,7 @@ emissionFactors:
         value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 24.000000000000004
+        value: 24.0
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 24.0
@@ -165,7 +165,7 @@ emissionFactors:
         value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 24.000000000000004
+        value: 24.0
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
         value: 24.0

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -130,25 +130,25 @@ emissionFactors:
         value: 24.000000000000004
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 24.000000000000004
+        value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 85.18178147013533
+        value: 85.18
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 104.6832783898639
+        value: 104.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 55.63483890608569
+        value: 55.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 65.12914061965704
+        value: 65.13
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 64.21039971020251
+        value: 64.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 95.71316508349986
+        value: 95.71
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -174,25 +174,25 @@ emissionFactors:
         value: 24.000000000000004
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 24.000000000000004
+        value: 24.0
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 85.18178147013533
+        value: 85.18
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 104.6832783898639
+        value: 104.68
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 55.63483890608569
+        value: 55.63
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 65.12914061965704
+        value: 65.13
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 64.21039971020251
+        value: 64.21
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 95.71316508349986
+        value: 95.71
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -180,25 +180,25 @@ emissionFactors:
         value: 647.5129689052843
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 770.149130502813
+        value: 770.15
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 785.5544860773409
+        value: 785.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 770.3541088303356
+        value: 770.35
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 772.364141815251
+        value: 772.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 751.8332336609881
+        value: 751.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 754.3879614023904
+        value: 754.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 698.0135217755937
+        value: 698.01
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -224,25 +224,25 @@ emissionFactors:
         value: 647.5129689052843
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 770.149130502813
+        value: 770.15
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 785.5544860773409
+        value: 785.55
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 770.3541088303356
+        value: 770.35
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 772.364141815251
+        value: 772.36
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 751.8332336609881
+        value: 751.83
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 754.3879614023904
+        value: 754.39
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 698.0135217755937
+        value: 698.01
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -126,25 +126,25 @@ emissionFactors:
         value: 24.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 119.04789686665868
+        value: 119.05
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 450.42504096448533
+        value: 450.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 417.74667058653455
+        value: 417.75
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 359.3320045477184
+        value: 359.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 344.70520038212663
+        value: 344.71
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 335.5862488998276
+        value: 335.59
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 271.2247396128676
+        value: 271.22
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -163,25 +163,25 @@ emissionFactors:
         value: 24.0
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 119.04789686665868
+        value: 119.05
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 450.42504096448533
+        value: 450.43
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 417.74667058653455
+        value: 417.75
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 359.3320045477184
+        value: 359.33
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 344.70520038212663
+        value: 344.71
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 335.5862488998276
+        value: 335.59
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 271.2247396128676
+        value: 271.22
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -199,25 +199,25 @@ emissionFactors:
         value: 280.50405490271606
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 282.40418815974226
+        value: 282.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 267.09651997412
+        value: 267.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 254.25004794574977
+        value: 254.25
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 244.34964017048316
+        value: 244.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 266.00347622914967
+        value: 266.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 285.44194732672133
+        value: 285.44
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 281.42400355711464
+        value: 281.42
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -246,25 +246,25 @@ emissionFactors:
         value: 280.50405490271606
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 282.40418815974226
+        value: 282.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 267.09651997412
+        value: 267.1
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 254.25004794574977
+        value: 254.25
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 244.34964017048316
+        value: 244.35
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 266.00347622914967
+        value: 266.0
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 285.44194732672133
+        value: 285.44
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 281.42400355711464
+        value: 281.42
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -95,27 +95,27 @@ emissionFactors:
         value: 15.685873662533016
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 149.15155828964438
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 353.73942907490044
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 222.51899806861596
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 460.60358485920216
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 144.1825642555089
+        value: 144.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 149.15
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 353.74
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 222.52
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 460.6
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 426.29250272465555
+        value: 426.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 153.71839204309987
+        value: 153.72
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -125,33 +125,48 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 149.15155828964438
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 353.73942907490044
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 222.51899806861596
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 460.60358485920216
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 144.1825642555089
+        value: 144.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 149.15
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 353.74
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 222.52
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 460.6
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 426.29250272465555
+        value: 426.29
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 153.71839204309987
+        value: 153.72
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0654790569883904
+        gas: 0.06621268634586248
+        geothermal: 0.0
+        hydro: 0.32236638575904847
+        hydro discharge: 0.4659870174349138
+        nuclear: 0.0733624232507706
+        oil: 1.5648401611370587e-05
+        solar: 0.0017949988595360993
+        unknown: 0.00475584479815969
+        wind: 2.4684802541880363e-05
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
@@ -212,21 +227,6 @@ fallbackZoneMixes:
         solar: 0.0035333751175180192
         unknown: 0.01722679858530689
         wind: 7.565922012803868e-05
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0654790569883904
-        gas: 0.06621268634586248
-        geothermal: 0.0
-        hydro: 0.32236638575904847
-        hydro discharge: 0.4659870174349138
-        nuclear: 0.0733624232507706
-        oil: 1.5648401611370587e-05
-        solar: 0.0017949988595360993
-        unknown: 0.00475584479815969
-        wind: 2.4684802541880363e-05
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -206,25 +206,25 @@ emissionFactors:
         value: 479.48803925651623
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 464.36973390078464
+        value: 464.37
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 505.2520555531113
+        value: 505.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 488.32507405403845
+        value: 488.33
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 447.75685249370105
+        value: 447.76
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 464.21843919717884
+        value: 464.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.6574563106796
+        value: 465.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 432.2177621359223
+        value: 432.22
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -257,25 +257,25 @@ emissionFactors:
         value: 479.48803925651623
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 464.36973390078464
+        value: 464.37
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 505.2520555531113
+        value: 505.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 488.32507405403845
+        value: 488.33
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 447.75685249370105
+        value: 447.76
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 464.21843919717884
+        value: 464.22
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 465.6574563106796
+        value: 465.66
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 432.2177621359223
+        value: 432.22
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -156,25 +156,25 @@ emissionFactors:
         value: 402.78963651897595
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 457.4002335652466
+        value: 457.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 370.7024434037973
+        value: 370.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 331.6111419204539
+        value: 331.61
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 500.8942543150176
+        value: 500.89
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 448.0123536295956
+        value: 448.01
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 466.1743090700748
+        value: 466.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 430.04720532583235
+        value: 430.05
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -207,25 +207,25 @@ emissionFactors:
         value: 402.78963651897595
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 457.4002335652466
+        value: 457.4
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 370.7024434037973
+        value: 370.7
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 331.6111419204539
+        value: 331.61
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 500.8942543150176
+        value: 500.89
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 448.0123536295956
+        value: 448.01
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 466.1743090700748
+        value: 466.17
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 430.04720532583235
+        value: 430.05
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -130,25 +130,25 @@ emissionFactors:
         value: 628.6048672222605
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 622.4999140185001
+        value: 622.5
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 668.92801269558
+        value: 668.93
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 644.9451525440152
+        value: 644.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 646.1621183510472
+        value: 646.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 651.1973005543184
+        value: 651.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 613.5271066186818
+        value: 613.53
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 545.7958714972767
+        value: 545.8
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -169,25 +169,25 @@ emissionFactors:
         value: 628.6048672222605
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 622.4999140185001
+        value: 622.5
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 668.92801269558
+        value: 668.93
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 644.9451525440152
+        value: 644.95
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 646.1621183510472
+        value: 646.16
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 651.1973005543184
+        value: 651.2
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 613.5271066186818
+        value: 613.53
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 545.7958714972767
+        value: 545.8
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -162,25 +162,25 @@ emissionFactors:
         value: 673.1078913394612
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 569.5221558114126
+        value: 569.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 715.8742933053542
+        value: 715.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 671.4000176863626
+        value: 671.4
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 736.9523312883437
+        value: 736.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 680.3626380368098
+        value: 680.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 655.8535895319079
+        value: 655.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 247.53996932515338
+        value: 247.54
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -206,25 +206,25 @@ emissionFactors:
         value: 673.1078913394612
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 569.5221558114126
+        value: 569.52
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 715.8742933053542
+        value: 715.87
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 671.4000176863626
+        value: 671.4
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 736.9523312883437
+        value: 736.95
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 680.3626380368098
+        value: 680.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 655.8535895319079
+        value: 655.85
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 247.53996932515338
+        value: 247.54
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -154,25 +154,25 @@ emissionFactors:
         value: 269.9713981359454
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 247.7029935120496
+        value: 247.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 300.1710352953091
+        value: 300.17
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 348.4639862231487
+        value: 348.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 303.31075747973284
+        value: 303.31
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 280.53518498238407
+        value: 280.54
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 271.0437010709076
+        value: 271.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 304.6968730351475
+        value: 304.7
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -196,25 +196,25 @@ emissionFactors:
         value: 269.9713981359454
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 247.7029935120496
+        value: 247.7
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 300.1710352953091
+        value: 300.17
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 348.4639862231487
+        value: 348.46
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 303.31075747973284
+        value: 303.31
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 280.53518498238407
+        value: 280.54
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 271.0437010709076
+        value: 271.04
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 304.6968730351475
+        value: 304.7
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -146,25 +146,25 @@ emissionFactors:
         value: 788.3906851324865
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 756.1700634083586
+        value: 756.17
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 724.2526395854458
+        value: 724.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 674.3227519193904
+        value: 674.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 679.2408861774468
+        value: 679.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 641.9853722039774
+        value: 641.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 613.4738126839889
+        value: 613.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 593.2051862060505
+        value: 593.21
     coal:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -188,25 +188,25 @@ emissionFactors:
         value: 788.3906851324865
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 756.1700634083586
+        value: 756.17
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 724.2526395854458
+        value: 724.25
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 674.3227519193904
+        value: 674.32
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 679.2408861774468
+        value: 679.24
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 641.9853722039774
+        value: 641.99
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 613.4738126839889
+        value: 613.47
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 593.2051862060505
+        value: 593.21
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -142,25 +142,25 @@ emissionFactors:
         value: 542.1413552404729
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 589.548452323098
+        value: 589.55
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 571.8994500444788
+        value: 571.9
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 370.1867876697655
+        value: 370.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 439.4166173790383
+        value: 439.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 370.3272944575323
+        value: 370.33
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 380.11141092469353
+        value: 380.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 511.56010227991226
+        value: 511.56
     coal:
       - datetime: '2012-01-01'
         source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -186,25 +186,25 @@ emissionFactors:
         value: 542.1413552404729
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 589.548452323098
+        value: 589.55
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 571.8994500444788
+        value: 571.9
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 370.1867876697655
+        value: 370.19
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 439.4166173790383
+        value: 439.42
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 370.3272944575323
+        value: 370.33
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 380.11141092469353
+        value: 380.11
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 511.56010227991226
+        value: 511.56
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -166,25 +166,25 @@ emissionFactors:
         value: 344.0990347035266
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 358.7214677977783
+        value: 358.72
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 414.88859224160336
+        value: 414.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 476.45425589663347
+        value: 476.45
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 313.3847322251119
+        value: 313.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 360.8787326581616
+        value: 360.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 420.9866166915331
+        value: 420.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 361.7327444391022
+        value: 361.73
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -217,25 +217,25 @@ emissionFactors:
         value: 344.0990347035266
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 358.7214677977783
+        value: 358.72
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 414.88859224160336
+        value: 414.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 476.45425589663347
+        value: 476.45
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 313.3847322251119
+        value: 313.38
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 360.8787326581616
+        value: 360.88
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 420.9866166915331
+        value: 420.99
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 361.7327444391022
+        value: 361.73
     oil:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -235,25 +235,25 @@ emissionFactors:
         value: 445.7752079446886
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 428.6147495311597
+        value: 428.61
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 527.8922617445895
+        value: 527.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 468.714286024875
+        value: 468.71
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 435.47491994591104
+        value: 435.47
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 426.30370659220654
+        value: 426.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.3799163384898
+        value: 405.38
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 388.7735065528539
+        value: 388.77
     biomass:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -286,25 +286,25 @@ emissionFactors:
         value: 445.7752079446886
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 428.6147495311597
+        value: 428.61
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 527.8922617445895
+        value: 527.89
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 468.714286024875
+        value: 468.71
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 435.47491994591104
+        value: 435.47
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 426.30370659220654
+        value: 426.3
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 405.3799163384898
+        value: 405.38
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 388.7735065528539
+        value: 388.77
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -68,24 +68,24 @@ emissionFactors:
       value: 803.8986689
   lifecycle:
     battery discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 439.95857845249066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 441.3591005975944
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 500.6381504824308
+        value: 500.64
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 462.9830938143178
+        value: 462.98
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 439.96
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 441.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 418.81117311932985
+        value: 418.81
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 400.60435418169976
+        value: 400.6
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -103,24 +103,24 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 108.87985131
     hydro discharge:
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 439.95857845249066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 441.3591005975944
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 500.6381504824308
+        value: 500.64
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 462.9830938143178
+        value: 462.98
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 439.96
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 441.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 418.81117311932985
+        value: 418.81
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 400.60435418169976
+        value: 400.6
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/UY.yaml
+++ b/config/zones/UY.yaml
@@ -92,59 +92,59 @@ emissionFactors:
     battery discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 44.383237421396466
+        value: 44.38
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 65.19018370828374
+        value: 65.19
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 46.943955459838016
+        value: 46.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 51.66268610438768
+        value: 51.66
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 45.1013391069673
+        value: 45.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 91.61742339917477
+        value: 91.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 145.21391641089318
+        value: 145.21
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.1827833031807
+        value: 99.18
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 97.04750297572436
+        value: 97.05
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
-        value: 44.383237421396466
+        value: 44.38
       - datetime: '2016-01-01'
         source: Electricity Maps, 2016 average
-        value: 65.19018370828374
+        value: 65.19
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 46.943955459838016
+        value: 46.94
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 51.66268610438768
+        value: 51.66
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 45.1013391069673
+        value: 45.1
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 91.61742339917477
+        value: 91.62
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 145.21391641089318
+        value: 145.21
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 99.1827833031807
+        value: 99.18
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 97.04750297572436
+        value: 97.05
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/XK.yaml
+++ b/config/zones/XK.yaml
@@ -33,66 +33,51 @@ emissionFactors:
         value: 759.9999999999999
   lifecycle:
     battery discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 789.5267284101014
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 783.9886277112009
+        value: 783.99
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 789.53
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 712.21658924177
+        value: 712.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 675.3630655728737
+        value: 675.36
     hydro discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 789.5267284101014
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 775.7559374698326
+        value: 775.76
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 783.9886277112009
+        value: 783.99
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 789.53
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 712.21658924177
+        value: 712.22
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 675.3630655728737
+        value: 675.36
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 2.190673855736205e-05
-        coal: 0.9621516865325653
-        gas: 2.83299960271291e-05
-        geothermal: 0.0
-        hydro: 0.004954533723725316
-        hydro discharge: 2.1747066146718074e-05
-        nuclear: 7.286753219210013e-05
-        oil: 0.0
-        solar: 2.5674058899585747e-06
-        unknown: 7.760079157297203e-05
-        wind: 0.03266783221624355
     - _source: Electricity Maps, 2017 average
       datetime: '2017-01-01'
       value:
@@ -153,6 +138,21 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.04020071233816791
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 2.190673855736205e-05
+        coal: 0.9621516865325653
+        gas: 2.83299960271291e-05
+        geothermal: 0.0
+        hydro: 0.004954533723725316
+        hydro discharge: 2.1747066146718074e-05
+        nuclear: 7.286753219210013e-05
+        oil: 0.0
+        solar: 2.5674058899585747e-06
+        unknown: 7.760079157297203e-05
+        wind: 0.03266783221624355
     - _source: Electricity Maps, 2022 average
       datetime: '2022-01-01'
       value:

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -115,25 +115,25 @@ emissionFactors:
         value: 713.4982281617381
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 707.3380696616895
+        value: 707.34
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 735.4353145546338
+        value: 735.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 719.1121127719948
+        value: 719.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 715.1130837187634
+        value: 715.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 702.3630492950823
+        value: 702.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 698.1508087487392
+        value: 698.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 702.8248650501995
+        value: 702.82
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -143,25 +143,25 @@ emissionFactors:
         value: 713.4982281617381
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
-        value: 707.3380696616895
+        value: 707.34
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
-        value: 735.4353145546338
+        value: 735.44
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
-        value: 719.1121127719948
+        value: 719.11
       - datetime: '2020-01-01'
         source: Electricity Maps, 2020 average
-        value: 715.1130837187634
+        value: 715.11
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
-        value: 702.3630492950823
+        value: 702.36
       - datetime: '2022-01-01'
         source: Electricity Maps, 2022 average
-        value: 698.1508087487392
+        value: 698.15
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
-        value: 702.8248650501995
+        value: 702.82
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/mobileapp/pnpm-lock.yaml
+++ b/mobileapp/pnpm-lock.yaml
@@ -355,8 +355,8 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
   buffer-crc32@0.2.13:
@@ -667,8 +667,8 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
-  fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
   find-up@2.1.0:
@@ -743,6 +743,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -811,6 +812,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -995,8 +997,8 @@ packages:
   mergexml@1.2.4:
     resolution: {integrity: sha512-yiOlDqcVCz7AG1eSboonc18FTlfqDEKYfGoAV3Lul98u6YRV/s0kjtf4bjk47t0hLTFJR0BSYMd6BpmX3xDjNQ==}
 
-  micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
   mimic-response@3.1.0:
@@ -1254,6 +1256,10 @@ packages:
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1325,6 +1331,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@4.4.1:
@@ -2201,9 +2208,9 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braces@3.0.2:
+  braces@3.0.3:
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   buffer-crc32@0.2.13: {}
 
@@ -2238,7 +2245,7 @@ snapshots:
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -2544,7 +2551,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   fastq@1.17.1:
     dependencies:
@@ -2554,7 +2561,7 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fill-range@7.0.1:
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
@@ -2861,9 +2868,9 @@ snapshots:
       formidable: 3.5.1
       xpath: 0.0.27
 
-  micromatch@4.0.5:
+  micromatch@4.0.8:
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
 
   mimic-response@3.1.0: {}

--- a/mockserver/pnpm-lock.yaml
+++ b/mockserver/pnpm-lock.yaml
@@ -57,8 +57,8 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
   bytes@3.1.2:
@@ -162,8 +162,8 @@ packages:
     resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
 
-  fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
   finalhandler@1.3.1:
@@ -262,10 +262,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -374,8 +370,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -441,9 +437,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
 snapshots:
 
   abbrev@1.1.1: {}
@@ -496,9 +489,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  braces@3.0.2:
+  braces@3.0.3:
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   bytes@3.1.2: {}
 
@@ -513,7 +506,7 @@ snapshots:
   chokidar@3.5.3:
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -617,7 +610,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fill-range@7.0.1:
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
@@ -710,10 +703,6 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-
   media-typer@0.3.0: {}
 
   merge-descriptors@1.0.3: {}
@@ -747,7 +736,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 7.5.4
+      semver: 7.6.3
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.0
@@ -803,9 +792,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
+  semver@7.6.3: {}
 
   send@0.19.0:
     dependencies:
@@ -854,7 +841,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.3
 
   statuses@2.0.1: {}
 
@@ -884,5 +871,3 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
-
-  yallist@4.0.0: {}

--- a/parsers/test/test_config.py
+++ b/parsers/test/test_config.py
@@ -16,14 +16,14 @@ class EmissionFactorTestCase(unittest.TestCase):
         # KR - no override
         expected = {
             "battery charge": 0,
-            "battery discharge": 421.93595411096464,
+            "battery discharge": 421.94,
             "biomass": 230,
             "coal": 820,
             "gas": 490,
             "geothermal": 38,
             "hydro": 24,
             "hydro charge": 0,
-            "hydro discharge": 421.93595411096464,
+            "hydro discharge": 421.94,
             "nuclear": 12,
             "oil": 650,
             "solar": 45,
@@ -35,14 +35,14 @@ class EmissionFactorTestCase(unittest.TestCase):
         # FR - override
         expected = {
             "battery charge": 0,
-            "battery discharge": 43.68594370851051,
+            "battery discharge": 43.69,
             "biomass": 230.0,
             "coal": 983.04,
             "gas": 511.79,
             "geothermal": 38,
             "hydro": 10.7,
             "hydro charge": 0,
-            "hydro discharge": 43.68594370851051,
+            "hydro discharge": 43.69,
             "nuclear": 5.13,
             "oil": 901.06,
             "solar": 30.075,

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electricitymaps-web",
-  "version": "1.174.0",
+  "version": "1.175.0",
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "repository": {
     "type": "git",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -224,7 +224,7 @@ importers:
         version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.4)(typescript@5.5.4)
       '@storybook/react-vite':
         specifier: ^8.3.4
-        version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.1)(storybook@8.3.4)(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))(webpack-sources@3.2.3)
+        version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.3.4)(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))(webpack-sources@3.2.3)
       '@storybook/test':
         specifier: ^8.3.4
         version: 8.3.4(storybook@8.3.4)
@@ -469,20 +469,40 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.25.7':
+    resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.25.4':
     resolution: {integrity: sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.25.7':
+    resolution: {integrity: sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.25.2':
     resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.25.7':
+    resolution: {integrity: sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.25.6':
     resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.25.7':
+    resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.24.7':
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.25.7':
+    resolution: {integrity: sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
@@ -493,14 +513,30 @@ packages:
     resolution: {integrity: sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.25.7':
+    resolution: {integrity: sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-create-class-features-plugin@7.25.4':
     resolution: {integrity: sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-create-class-features-plugin@7.25.7':
+    resolution: {integrity: sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-create-regexp-features-plugin@7.25.2':
     resolution: {integrity: sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-regexp-features-plugin@7.25.7':
+    resolution: {integrity: sha512-byHhumTj/X47wJ6C6eLpK7wW/WBEcnUeb7D0FNc/jFQnQVw7DOso3Zz5u9x/zLrFVkHa89ZGDbkAa1D54NdrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -518,8 +554,16 @@ packages:
     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-member-expression-to-functions@7.25.7':
+    resolution: {integrity: sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.24.7':
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.7':
+    resolution: {integrity: sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.25.2':
@@ -528,16 +572,36 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.25.7':
+    resolution: {integrity: sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-optimise-call-expression@7.24.7':
     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-optimise-call-expression@7.25.7':
+    resolution: {integrity: sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.24.8':
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.25.7':
+    resolution: {integrity: sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-remap-async-to-generator@7.25.0':
     resolution: {integrity: sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-remap-async-to-generator@7.25.7':
+    resolution: {integrity: sha512-kRGE89hLnPfcz6fTrlNU+uhgcwv0mBE4Gv3P9Ke9kLVJYpi4AMVVEElXvB5CabrPZW4nCM8P8UyyjrzCM0O2sw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -548,40 +612,83 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@7.25.7':
+    resolution: {integrity: sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-simple-access@7.24.7':
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-simple-access@7.25.7':
+    resolution: {integrity: sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.7':
+    resolution: {integrity: sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.25.7':
+    resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.25.7':
+    resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.24.8':
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.7':
+    resolution: {integrity: sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.25.0':
     resolution: {integrity: sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-wrap-function@7.25.7':
+    resolution: {integrity: sha512-MA0roW3JF2bD1ptAaJnvcabsVlNQShUaThyJbCDD4bCp8NEgiFvpoqRI2YS22hHlc2thjO/fTg2ShLMC3jygAg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helpers@7.25.6':
     resolution: {integrity: sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.25.7':
+    resolution: {integrity: sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/highlight@7.25.7':
+    resolution: {integrity: sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.25.6':
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.25.7':
+    resolution: {integrity: sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -629,8 +736,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-proposal-export-default-from@7.24.7':
-    resolution: {integrity: sha512-CcmFwUJ3tKhLjPdt4NP+SHMshebytF8ZTYOv5ZDpkzq2sin80Wb5vJrGt8fhPrORQCfoSa0LAxC/DW+GAC5+Hw==}
+  '@babel/plugin-proposal-export-default-from@7.25.7':
+    resolution: {integrity: sha512-Egdiuy7pLTyaPkIr6rItNyFVbblTmx3VgqY+72KiS9BzcA+SMyrS9zSumQeSANo8uE3Kax0ZUMkpNh0Q+mbNwg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -697,8 +804,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-export-default-from@7.24.7':
-    resolution: {integrity: sha512-bTPz4/635WQ9WhwsyPdxUJDVpsi/X9BMmy/8Rf/UAlOO4jSql4CxUCjWI5PiM+jG+c4LVPTScoTw80geFj9+Bw==}
+  '@babel/plugin-syntax-export-default-from@7.25.7':
+    resolution: {integrity: sha512-LRUCsC0YucSjabsmxx6yly8+Q/5mxKdp9gemlpR9ro3bfpcOQOXx/CHivs7QCbjgygd6uQ2GcRfHu1FVax/hgg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -708,8 +815,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-flow@7.24.7':
-    resolution: {integrity: sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==}
+  '@babel/plugin-syntax-flow@7.25.7':
+    resolution: {integrity: sha512-fyoj6/YdVtlv2ROig/J0fP7hh/wNO1MJGm1NR70Pg7jbkF+jOUL9joorqaCOQh06Y+LfgTagHzC8KqZ3MF782w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -736,8 +843,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-jsx@7.24.7':
-    resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
+  '@babel/plugin-syntax-jsx@7.25.7':
+    resolution: {integrity: sha512-ruZOnKO+ajVL/MVx+PwNBPOkrnXTXoWMtte1MBpegfCArhqOe3Bj52avVj1huLLxNKYKXYaSxZ2F+woK1ekXfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -784,8 +891,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-typescript@7.25.4':
-    resolution: {integrity: sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==}
+  '@babel/plugin-syntax-typescript@7.25.7':
+    resolution: {integrity: sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -802,6 +909,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-arrow-functions@7.25.7':
+    resolution: {integrity: sha512-EJN2mKxDwfOUCPxMO6MUI58RN3ganiRAG/MS/S3HfB6QFNjroAMelQo/gybyYq97WerCBAZoyrAoW8Tzdq2jWg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-async-generator-functions@7.25.4':
     resolution: {integrity: sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==}
     engines: {node: '>=6.9.0'}
@@ -814,6 +927,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-async-to-generator@7.25.7':
+    resolution: {integrity: sha512-ZUCjAavsh5CESCmi/xCpX1qcCaAglzs/7tmuvoFnJgA1dM7gQplsguljoTg+Ru8WENpX89cQyAtWoaE0I3X3Pg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-block-scoped-functions@7.24.7':
     resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
     engines: {node: '>=6.9.0'}
@@ -822,6 +941,12 @@ packages:
 
   '@babel/plugin-transform-block-scoping@7.25.0':
     resolution: {integrity: sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-block-scoping@7.25.7':
+    resolution: {integrity: sha512-ZEPJSkVZaeTFG/m2PARwLZQ+OG0vFIhPlKHK/JdIMy8DbRJ/htz6LRrTFtdzxi9EHmcwbNPAKDnadpNSIW+Aow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -844,14 +969,32 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-classes@7.25.7':
+    resolution: {integrity: sha512-9j9rnl+YCQY0IGoeipXvnk3niWicIB6kCsWRGLwX241qSXpbA4MKxtp/EdvFxsc4zI5vqfLxzOd0twIJ7I99zg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-computed-properties@7.24.7':
     resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-computed-properties@7.25.7':
+    resolution: {integrity: sha512-QIv+imtM+EtNxg/XBKL3hiWjgdLjMOmZ+XzQwSgmBfKbfxUjBzGgVPklUuE55eq5/uVoh8gg3dqlrwR/jw3ZeA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-destructuring@7.24.8':
     resolution: {integrity: sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@7.25.7':
+    resolution: {integrity: sha512-xKcfLTlJYUczdaM1+epcdh1UGewJqr9zATgrNHcLBcV2QmfvPPEixo/sK/syql9cEmbr7ulu5HMFG5vbbt/sEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -892,8 +1035,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-flow-strip-types@7.25.2':
-    resolution: {integrity: sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==}
+  '@babel/plugin-transform-flow-strip-types@7.25.7':
+    resolution: {integrity: sha512-q8Td2PPc6/6I73g96SreSUCKEcwMXCwcXSIAVTyTTN6CpJe0dMj8coxu1fg1T9vfBLi6Rsi6a4ECcFBbKabS5w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -910,6 +1053,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-function-name@7.25.7':
+    resolution: {integrity: sha512-5MCTNcjCMxQ63Tdu9rxyN6cAWurqfrDZ76qvVPrGYdBxIj+EawuuxTu/+dgJlhK5eRz3v1gLwp6XwS8XaX2NiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-json-strings@7.24.7':
     resolution: {integrity: sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==}
     engines: {node: '>=6.9.0'}
@@ -918,6 +1067,12 @@ packages:
 
   '@babel/plugin-transform-literals@7.25.2':
     resolution: {integrity: sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-literals@7.25.7':
+    resolution: {integrity: sha512-fwzkLrSu2fESR/cm4t6vqd7ebNIopz2QHGtjoU+dswQo/P6lwAG04Q98lliE3jkz/XqnbGFLnUcE0q0CVUf92w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -946,6 +1101,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-commonjs@7.25.7':
+    resolution: {integrity: sha512-L9Gcahi0kKFYXvweO6n0wc3ZG1ChpSFdgG+eV1WYZ3/dGbJK7vvk91FgGgak8YwRgrCuihF8tE/Xg07EkL5COg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-modules-systemjs@7.25.0':
     resolution: {integrity: sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==}
     engines: {node: '>=6.9.0'}
@@ -960,6 +1121,12 @@ packages:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.24.7':
     resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.7':
+    resolution: {integrity: sha512-BtAT9LzCISKG3Dsdw5uso4oV1+v2NlVXIIomKJgQybotJY3OwCwJmkongjHgwGKoZXd0qG5UZ12JUlDQ07W6Ow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1012,8 +1179,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-parameters@7.25.7':
+    resolution: {integrity: sha512-FYiTvku63me9+1Nz7TOx4YMtW3tWXzfANZtrzHhUZrz4d47EEtMQhzFoZWESfXuAMMT5mwzD4+y1N8ONAX6lMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-private-methods@7.25.4':
     resolution: {integrity: sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-methods@7.25.7':
+    resolution: {integrity: sha512-KY0hh2FluNxMLwOCHbxVOKfdB5sjWG4M183885FmaqWWiGMhRZq4DQRKH6mHdEucbJnyDyYiZNwNG424RymJjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1024,32 +1203,38 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-private-property-in-object@7.25.7':
+    resolution: {integrity: sha512-LzA5ESzBy7tqj00Yjey9yWfs3FKy4EmJyKOSWld144OxkTji81WWnUT8nkLUn+imN/zHL8ZQlOu/MTUAhHaX3g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-property-literals@7.24.7':
     resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-display-name@7.24.7':
-    resolution: {integrity: sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==}
+  '@babel/plugin-transform-react-display-name@7.25.7':
+    resolution: {integrity: sha512-r0QY7NVU8OnrwE+w2IWiRom0wwsTbjx4+xH2RTd7AVdof3uurXOF+/mXHQDRk+2jIvWgSaCHKMgggfvM4dyUGA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.24.7':
-    resolution: {integrity: sha512-fOPQYbGSgH0HUp4UJO4sMBFjY6DuWq+2i8rixyUMb3CdGixs/gccURvYOAhajBdKDoGajFr3mUq5rH3phtkGzw==}
+  '@babel/plugin-transform-react-jsx-self@7.25.7':
+    resolution: {integrity: sha512-JD9MUnLbPL0WdVK8AWC7F7tTG2OS6u/AKKnsK+NdRhUiVdnzyR1S3kKQCaRLOiaULvUiqK6Z4JQE635VgtCFeg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.24.7':
-    resolution: {integrity: sha512-J2z+MWzZHVOemyLweMqngXrgGC42jQ//R0KdxqkIz/OrbVIIlhFI3WigZ5fO+nwFvBlncr4MGapd8vTyc7RPNQ==}
+  '@babel/plugin-transform-react-jsx-source@7.25.7':
+    resolution: {integrity: sha512-S/JXG/KrbIY06iyJPKfxr0qRxnhNOdkNXYBl/rmwgDd72cQLH9tEGkDm/yJPGvcSIUoikzfjMios9i+xT/uv9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx@7.25.2':
-    resolution: {integrity: sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==}
+  '@babel/plugin-transform-react-jsx@7.25.7':
+    resolution: {integrity: sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1066,8 +1251,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-runtime@7.25.4':
-    resolution: {integrity: sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==}
+  '@babel/plugin-transform-runtime@7.25.7':
+    resolution: {integrity: sha512-Y9p487tyTzB0yDYQOtWnC+9HGOuogtP3/wNpun1xJXEEvI6vip59BSBTsHnekZLqxmPcgsrAKt46HAAb//xGhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1078,14 +1263,32 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-shorthand-properties@7.25.7':
+    resolution: {integrity: sha512-uBbxNwimHi5Bv3hUccmOFlUy3ATO6WagTApenHz9KzoIdn0XeACdB12ZJ4cjhuB2WSi80Ez2FWzJnarccriJeA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-spread@7.24.7':
     resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-spread@7.25.7':
+    resolution: {integrity: sha512-Mm6aeymI0PBh44xNIv/qvo8nmbkpZze1KvR8MkEqbIREDxoiWTi18Zr2jryfRMwDfVZF9foKh060fWgni44luw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-sticky-regex@7.24.7':
     resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-sticky-regex@7.25.7':
+    resolution: {integrity: sha512-ZFAeNkpGuLnAQ/NCsXJ6xik7Id+tHuS+NT+ue/2+rn/31zcdnupCdmunOizEaP0JsUmTFSTOPoQY7PkK2pttXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1102,8 +1305,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typescript@7.25.2':
-    resolution: {integrity: sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==}
+  '@babel/plugin-transform-typescript@7.25.7':
+    resolution: {integrity: sha512-VKlgy2vBzj8AmEzunocMun2fF06bsSWV+FvVXohtL6FGve/+L217qhHxRTVGHEDO/YR8IANcjzgJsd04J8ge5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1126,6 +1329,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-unicode-regex@7.25.7':
+    resolution: {integrity: sha512-8JKfg/hiuA3qXnlLx8qtv5HWRbgyFx2hMMtpDDuU2rTckpKkGu4ycK5yYHwuEa16/quXfoxHBIApEsNyMWnt0g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-unicode-sets-regex@7.25.4':
     resolution: {integrity: sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==}
     engines: {node: '>=6.9.0'}
@@ -1138,8 +1347,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/preset-flow@7.24.7':
-    resolution: {integrity: sha512-NL3Lo0NorCU607zU3NwRyJbpaB6E3t0xtd3LfAQKDfkeX4/ggcDXvkmkW42QWT5owUeW/jAe4hn+2qvkV1IbfQ==}
+  '@babel/preset-flow@7.25.7':
+    resolution: {integrity: sha512-q2x3g0YHzo/Ohsr51KOYS/BtZMsvkzVd8qEyhZAyTatYdobfgXCuyppTqTuIhdq5kR/P3nyyVvZ6H5dMc4PnCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1149,14 +1358,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
 
-  '@babel/preset-typescript@7.24.7':
-    resolution: {integrity: sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==}
+  '@babel/preset-typescript@7.25.7':
+    resolution: {integrity: sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/register@7.24.6':
-    resolution: {integrity: sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==}
+  '@babel/register@7.25.7':
+    resolution: {integrity: sha512-qHTd2Rhn/rKhSUwdY6+n98FmwXN+N+zxSVx3zWqRe9INyvTpv+aQ5gDV2+43ACd3VtMBzPPljbb0gZb8u5ma6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1168,16 +1377,32 @@ packages:
     resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.25.7':
+    resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.25.0':
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.25.7':
+    resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.25.6':
     resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.25.7':
+    resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.25.7':
+    resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
     engines: {node: '>=6.9.0'}
 
   '@base2/pretty-print-object@1.0.1':
@@ -2366,83 +2591,83 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.21.3':
-    resolution: {integrity: sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==}
+  '@rollup/rollup-android-arm-eabi@4.24.0':
+    resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.21.3':
-    resolution: {integrity: sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==}
+  '@rollup/rollup-android-arm64@4.24.0':
+    resolution: {integrity: sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.21.3':
-    resolution: {integrity: sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==}
+  '@rollup/rollup-darwin-arm64@4.24.0':
+    resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.21.3':
-    resolution: {integrity: sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==}
+  '@rollup/rollup-darwin-x64@4.24.0':
+    resolution: {integrity: sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.3':
-    resolution: {integrity: sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
+    resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.21.3':
-    resolution: {integrity: sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
+    resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.3':
-    resolution: {integrity: sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==}
+  '@rollup/rollup-linux-arm64-gnu@4.24.0':
+    resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.21.3':
-    resolution: {integrity: sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==}
+  '@rollup/rollup-linux-arm64-musl@4.24.0':
+    resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.3':
-    resolution: {integrity: sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
+    resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.21.3':
-    resolution: {integrity: sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==}
+  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
+    resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.3':
-    resolution: {integrity: sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==}
+  '@rollup/rollup-linux-s390x-gnu@4.24.0':
+    resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.21.3':
-    resolution: {integrity: sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==}
+  '@rollup/rollup-linux-x64-gnu@4.24.0':
+    resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.21.3':
-    resolution: {integrity: sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==}
+  '@rollup/rollup-linux-x64-musl@4.24.0':
+    resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.21.3':
-    resolution: {integrity: sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==}
+  '@rollup/rollup-win32-arm64-msvc@4.24.0':
+    resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.3':
-    resolution: {integrity: sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==}
+  '@rollup/rollup-win32-ia32-msvc@4.24.0':
+    resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.21.3':
-    resolution: {integrity: sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==}
+  '@rollup/rollup-win32-x64-msvc@4.24.0':
+    resolution: {integrity: sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==}
     cpu: [x64]
     os: [win32]
 
@@ -4145,6 +4370,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.24.0:
+    resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
@@ -4220,6 +4450,9 @@ packages:
 
   caniuse-lite@1.0.30001655:
     resolution: {integrity: sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==}
+
+  caniuse-lite@1.0.30001667:
+    resolution: {integrity: sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -4754,6 +4987,9 @@ packages:
   electron-to-chromium@1.5.13:
     resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
 
+  electron-to-chromium@1.5.32:
+    resolution: {integrity: sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -4847,6 +5083,10 @@ packages:
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
@@ -4997,6 +5237,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -7251,6 +7492,10 @@ packages:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
     engines: {node: '>=4'}
 
+  regenerate-unicode-properties@10.2.0:
+    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
+    engines: {node: '>=4'}
+
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
 
@@ -7275,8 +7520,19 @@ packages:
     resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
     engines: {node: '>=4'}
 
+  regexpu-core@6.1.1:
+    resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
+    engines: {node: '>=4'}
+
+  regjsgen@0.8.0:
+    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
+    hasBin: true
+
+  regjsparser@0.11.1:
+    resolution: {integrity: sha512-1DHODs4B8p/mQHU9kr+jv8+wIC9mtG4eBHxWxIq5mhjE3D5oORhCc6deRKzTjs9DcfRFmj9BHSDguZklqCGFWQ==}
     hasBin: true
 
   regjsparser@0.9.1:
@@ -7363,13 +7619,13 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
-  rollup@2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+  rollup@2.79.2:
+    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  rollup@4.21.3:
-    resolution: {integrity: sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==}
+  rollup@4.24.0:
+    resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8097,6 +8353,10 @@ packages:
     resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
     engines: {node: '>=4'}
 
+  unicode-match-property-value-ecmascript@2.2.0:
+    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
+    engines: {node: '>=4'}
+
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
@@ -8156,6 +8416,12 @@ packages:
 
   update-browserslist-db@1.1.0:
     resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.1.1:
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -8621,7 +8887,14 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
+  '@babel/code-frame@7.25.7':
+    dependencies:
+      '@babel/highlight': 7.25.7
+      picocolors: 1.1.0
+
   '@babel/compat-data@7.25.4': {}
+
+  '@babel/compat-data@7.25.7': {}
 
   '@babel/core@7.25.2':
     dependencies:
@@ -8643,6 +8916,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.25.7':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/helper-compilation-targets': 7.25.7
+      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.7)
+      '@babel/helpers': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/template': 7.25.7
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
+      convert-source-map: 2.0.0
+      debug: 4.3.7
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
@@ -8650,9 +8943,20 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
+  '@babel/generator@7.25.7':
+    dependencies:
+      '@babel/types': 7.25.7
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@babel/helper-annotate-as-pure@7.25.7':
+    dependencies:
+      '@babel/types': 7.25.7
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
@@ -8669,6 +8973,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@7.25.7':
+    dependencies:
+      '@babel/compat-data': 7.25.7
+      '@babel/helper-validator-option': 7.25.7
+      browserslist: 4.24.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.25.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -8682,11 +8994,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-member-expression-to-functions': 7.25.7
+      '@babel/helper-optimise-call-expression': 7.25.7
+      '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+      '@babel/traverse': 7.25.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-member-expression-to-functions': 7.25.7
+      '@babel/helper-optimise-call-expression': 7.25.7
+      '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+      '@babel/traverse': 7.25.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-regexp-features-plugin@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
+      semver: 6.3.1
+
+  '@babel/helper-create-regexp-features-plugin@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.7
+      regexpu-core: 6.1.1
       semver: 6.3.1
 
   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.25.2)':
@@ -8702,7 +9047,7 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.7
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
@@ -8711,10 +9056,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-member-expression-to-functions@7.25.7':
+    dependencies:
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.24.7':
     dependencies:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.25.7':
+    dependencies:
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8728,11 +9087,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-simple-access': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-simple-access': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
       '@babel/types': 7.25.6
 
+  '@babel/helper-optimise-call-expression@7.25.7':
+    dependencies:
+      '@babel/types': 7.25.7
+
   '@babel/helper-plugin-utils@7.24.8': {}
+
+  '@babel/helper-plugin-utils@7.25.7': {}
 
   '@babel/helper-remap-async-to-generator@7.25.0(@babel/core@7.25.2)':
     dependencies:
@@ -8740,6 +9125,15 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-wrap-function': 7.25.0
       '@babel/traverse': 7.25.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-remap-async-to-generator@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-wrap-function': 7.25.7
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8752,10 +9146,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-member-expression-to-functions': 7.25.7
+      '@babel/helper-optimise-call-expression': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-member-expression-to-functions': 7.25.7
+      '@babel/helper-optimise-call-expression': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-simple-access@7.25.7':
+    dependencies:
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8766,11 +9185,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.7':
+    dependencies:
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.24.8': {}
+
+  '@babel/helper-string-parser@7.25.7': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
+  '@babel/helper-validator-identifier@7.25.7': {}
+
   '@babel/helper-validator-option@7.24.8': {}
+
+  '@babel/helper-validator-option@7.25.7': {}
 
   '@babel/helper-wrap-function@7.25.0':
     dependencies:
@@ -8780,10 +9212,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-wrap-function@7.25.7':
+    dependencies:
+      '@babel/template': 7.25.7
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helpers@7.25.6':
     dependencies:
       '@babel/template': 7.25.0
       '@babel/types': 7.25.6
+
+  '@babel/helpers@7.25.7':
+    dependencies:
+      '@babel/template': 7.25.7
+      '@babel/types': 7.25.7
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -8792,9 +9237,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
+  '@babel/highlight@7.25.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.1.0
+
   '@babel/parser@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@babel/parser@7.25.7':
+    dependencies:
+      '@babel/types': 7.25.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.25.2)':
     dependencies:
@@ -8835,8 +9291,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
@@ -8844,50 +9300,73 @@ snapshots:
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.7)
+      '@babel/helper-plugin-utils': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-export-default-from@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-export-default-from': 7.25.7(@babel/core@7.25.2)
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
+
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.7)
 
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.25.2)':
     dependencies:
-      '@babel/compat-data': 7.25.4
+      '@babel/compat-data': 7.25.7
       '@babel/core': 7.25.2
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-compilation-targets': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-parameters': 7.25.7(@babel/core@7.25.2)
 
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -8915,20 +9394,25 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-export-default-from@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-export-default-from@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-flow@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-flow@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-import-assertions@7.25.6(@babel/core@7.25.2)':
     dependencies:
@@ -8950,10 +9434,15 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
     dependencies:
@@ -8963,6 +9452,11 @@ snapshots:
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
@@ -8985,6 +9479,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -8995,10 +9494,15 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-typescript@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-typescript@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.2)':
     dependencies:
@@ -9010,6 +9514,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-arrow-functions@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-async-generator-functions@7.25.4(@babel/core@7.25.2)':
     dependencies:
@@ -9030,6 +9539,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -9039,6 +9557,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-block-scoping@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-class-properties@7.25.4(@babel/core@7.25.2)':
     dependencies:
@@ -9069,16 +9592,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-classes@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-compilation-targets': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.2)
+      '@babel/traverse': 7.25.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
+  '@babel/plugin-transform-computed-properties@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/template': 7.25.7
+
   '@babel/plugin-transform-destructuring@7.24.8(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-destructuring@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -9117,11 +9663,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-flow-strip-types@7.25.2(@babel/core@7.25.2)':
+  '@babel/plugin-transform-flow-strip-types@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-flow': 7.25.7(@babel/core@7.25.2)
+
+  '@babel/plugin-transform-flow-strip-types@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-flow': 7.25.7(@babel/core@7.25.7)
 
   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -9140,6 +9692,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-compilation-targets': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -9150,6 +9711,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-literals@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -9179,6 +9745,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-commonjs@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-simple-access': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.7)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-simple-access': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-systemjs@7.25.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -9202,6 +9786,12 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -9256,11 +9846,24 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-parameters@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
+
   '@babel/plugin-transform-private-methods@7.25.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9274,34 +9877,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-transform-react-display-name@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-transform-react-jsx-self@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-transform-react-jsx-self@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-transform-react-jsx-source@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
+  '@babel/plugin-transform-react-jsx@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
-      '@babel/types': 7.25.6
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.2)
+      '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9316,11 +9929,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-runtime@7.25.4(@babel/core@7.25.2)':
+  '@babel/plugin-transform-runtime@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.2)
       babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.25.2)
       babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.25.2)
@@ -9333,6 +9946,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-shorthand-properties@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
+
   '@babel/plugin-transform-spread@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -9341,10 +9959,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-sticky-regex@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -9356,14 +9987,25 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2)':
+  '@babel/plugin-transform-typescript@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.25.2)
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+      '@babel/plugin-syntax-typescript': 7.25.7(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.25.7(@babel/core@7.25.7)':
+    dependencies:
+      '@babel/core': 7.25.7
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.25.7)
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
+      '@babel/plugin-syntax-typescript': 7.25.7(@babel/core@7.25.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -9383,6 +10025,12 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-unicode-regex@7.25.7(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.25.4(@babel/core@7.25.2)':
     dependencies:
@@ -9479,12 +10127,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-flow@7.24.7(@babel/core@7.25.2)':
+  '@babel/preset-flow@7.25.7(@babel/core@7.25.7)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-validator-option': 7.24.8
-      '@babel/plugin-transform-flow-strip-types': 7.25.2(@babel/core@7.25.2)
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-validator-option': 7.25.7
+      '@babel/plugin-transform-flow-strip-types': 7.25.7(@babel/core@7.25.7)
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.2)':
     dependencies:
@@ -9493,20 +10141,20 @@ snapshots:
       '@babel/types': 7.25.6
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.24.7(@babel/core@7.25.2)':
+  '@babel/preset-typescript@7.25.7(@babel/core@7.25.7)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-validator-option': 7.24.8
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
-      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
+      '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-validator-option': 7.25.7
+      '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.7)
+      '@babel/plugin-transform-modules-commonjs': 7.25.7(@babel/core@7.25.7)
+      '@babel/plugin-transform-typescript': 7.25.7(@babel/core@7.25.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.24.6(@babel/core@7.25.2)':
+  '@babel/register@7.25.7(@babel/core@7.25.7)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.7
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -9519,11 +10167,21 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@babel/runtime@7.25.7':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.25.0':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
+
+  '@babel/template@7.25.7':
+    dependencies:
+      '@babel/code-frame': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/types': 7.25.7
 
   '@babel/traverse@7.25.6':
     dependencies:
@@ -9537,10 +10195,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.25.7':
+    dependencies:
+      '@babel/code-frame': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/template': 7.25.7
+      '@babel/types': 7.25.7
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.25.6':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
+      to-fast-properties: 2.0.0
+
+  '@babel/types@7.25.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
   '@base2/pretty-print-object@1.0.1': {}
@@ -10606,42 +11282,42 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.25.2)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
-      '@babel/plugin-proposal-export-default-from': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-proposal-export-default-from': 7.25.7(@babel/core@7.25.2)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.25.2)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-export-default-from': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-flow': 7.25.7(@babel/core@7.25.2)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
-      '@babel/plugin-transform-classes': 7.25.4(@babel/core@7.25.2)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.25.2)
-      '@babel/plugin-transform-flow-strip-types': 7.25.2(@babel/core@7.25.2)
-      '@babel/plugin-transform-function-name': 7.25.1(@babel/core@7.25.2)
-      '@babel/plugin-transform-literals': 7.25.2(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-private-methods': 7.25.4(@babel/core@7.25.2)
-      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-runtime': 7.25.4(@babel/core@7.25.2)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.25.2)
-      '@babel/template': 7.25.0
+      '@babel/plugin-transform-arrow-functions': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-async-to-generator': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-block-scoping': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-classes': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-computed-properties': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-destructuring': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-flow-strip-types': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-function-name': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-literals': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-modules-commonjs': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-parameters': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-private-methods': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-private-property-in-object': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-display-name': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-self': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-source': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-runtime': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-shorthand-properties': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-spread': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-sticky-regex': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-typescript': 7.25.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-unicode-regex': 7.25.7(@babel/core@7.25.2)
+      '@babel/template': 7.25.7
       '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.25.4(@babel/core@7.25.2))
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.25.2)
       react-refresh: 0.14.2
@@ -10651,7 +11327,7 @@ snapshots:
 
   '@react-native/codegen@0.73.3(@babel/preset-env@7.25.4(@babel/core@7.25.2))':
     dependencies:
-      '@babel/parser': 7.25.6
+      '@babel/parser': 7.25.7
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
       flow-parser: 0.206.0
       glob: 7.2.3
@@ -10800,7 +11476,7 @@ snapshots:
 
   '@react-three/fiber@8.16.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(react@18.3.1))(react@18.3.1)(three@0.163.0)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.25.7
       '@types/react-reconciler': 0.26.7
       '@types/webxr': 0.5.20
       base64-js: 1.5.1
@@ -10819,103 +11495,103 @@ snapshots:
 
   '@remix-run/router@1.19.2': {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.1)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.24.7
-      '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
-      rollup: 2.79.1
+      '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
+      rollup: 2.79.2
     optionalDependencies:
       '@types/babel__core': 7.20.5
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-node-resolve@15.2.3(rollup@2.79.1)':
+  '@rollup/plugin-node-resolve@15.2.3(rollup@2.79.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.2(rollup@2.79.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
     optionalDependencies:
-      rollup: 2.79.1
+      rollup: 2.79.2
 
-  '@rollup/plugin-replace@2.4.2(rollup@2.79.1)':
+  '@rollup/plugin-replace@2.4.2(rollup@2.79.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
       magic-string: 0.25.9
-      rollup: 2.79.1
+      rollup: 2.79.2
 
-  '@rollup/plugin-terser@0.4.4(rollup@2.79.1)':
+  '@rollup/plugin-terser@0.4.4(rollup@2.79.2)':
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.32.0
     optionalDependencies:
-      rollup: 2.79.1
+      rollup: 2.79.2
 
-  '@rollup/pluginutils@3.1.0(rollup@2.79.1)':
+  '@rollup/pluginutils@3.1.0(rollup@2.79.2)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.79.1
+      rollup: 2.79.2
 
-  '@rollup/pluginutils@5.1.2(rollup@2.79.1)':
+  '@rollup/pluginutils@5.1.2(rollup@2.79.2)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 2.79.1
+      rollup: 2.79.2
 
-  '@rollup/rollup-android-arm-eabi@4.21.3':
+  '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.21.3':
+  '@rollup/rollup-android-arm64@4.24.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.21.3':
+  '@rollup/rollup-darwin-arm64@4.24.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.21.3':
+  '@rollup/rollup-darwin-x64@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.3':
+  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.21.3':
+  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.3':
+  '@rollup/rollup-linux-arm64-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.21.3':
+  '@rollup/rollup-linux-arm64-musl@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.3':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.21.3':
+  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.3':
+  '@rollup/rollup-linux-s390x-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.21.3':
+  '@rollup/rollup-linux-x64-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.21.3':
+  '@rollup/rollup-linux-x64-musl@4.24.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.21.3':
+  '@rollup/rollup-win32-arm64-msvc@4.24.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.3':
+  '@rollup/rollup-win32-ia32-msvc@4.24.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.21.3':
+  '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
   '@sentry-internal/browser-utils@8.32.0':
@@ -11333,10 +12009,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.4
 
-  '@storybook/react-vite@8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.1)(storybook@8.3.4)(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))(webpack-sources@3.2.3)':
+  '@storybook/react-vite@8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.3.4)(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))(webpack-sources@3.2.3)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))
-      '@rollup/pluginutils': 5.1.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.2(rollup@2.79.2)
       '@storybook/builder-vite': 8.3.4(storybook@8.3.4)(typescript@5.5.4)(vite@5.4.6(@types/node@20.16.10)(less@4.2.0)(terser@5.34.1))(webpack-sources@3.2.3)
       '@storybook/react': 8.3.4(@storybook/test@8.3.4(storybook@8.3.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.4)(typescript@5.5.4)
       find-up: 5.0.0
@@ -13367,9 +14043,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  babel-core@7.0.0-bridge.0(@babel/core@7.25.2):
+  babel-core@7.0.0-bridge.0(@babel/core@7.25.7):
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.7
 
   babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.25.2):
     dependencies:
@@ -13397,7 +14073,7 @@ snapshots:
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.25.2):
     dependencies:
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-flow': 7.25.7(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -13473,6 +14149,13 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
+  browserslist@4.24.0:
+    dependencies:
+      caniuse-lite: 1.0.30001667
+      electron-to-chromium: 1.5.32
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1(browserslist@4.24.0)
+
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -13537,6 +14220,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001655: {}
+
+  caniuse-lite@1.0.30001667: {}
 
   caseless@0.12.0: {}
 
@@ -14092,6 +14777,8 @@ snapshots:
 
   electron-to-chromium@1.5.13: {}
 
+  electron-to-chromium@1.5.32: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -14287,6 +14974,8 @@ snapshots:
       '@esbuild/win32-x64': 0.23.1
 
   escalade@3.1.2: {}
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -15428,7 +16117,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.25.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -15505,17 +16194,17 @@ snapshots:
 
   jscodeshift@0.14.0(@babel/preset-env@7.25.4(@babel/core@7.25.2)):
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/parser': 7.25.6
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
+      '@babel/core': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.7)
+      '@babel/plugin-transform-modules-commonjs': 7.25.7(@babel/core@7.25.7)
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
-      '@babel/preset-flow': 7.24.7(@babel/core@7.25.2)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
-      '@babel/register': 7.24.6(@babel/core@7.25.2)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.25.2)
+      '@babel/preset-flow': 7.25.7(@babel/core@7.25.7)
+      '@babel/preset-typescript': 7.25.7(@babel/core@7.25.7)
+      '@babel/register': 7.25.7(@babel/core@7.25.7)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.25.7)
       chalk: 4.1.2
       flow-parser: 0.206.0
       graceful-fs: 4.2.11
@@ -15897,7 +16586,7 @@ snapshots:
 
   metro-babel-transformer@0.80.12:
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.7
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.23.1
       nullthrows: 1.1.1
@@ -15964,13 +16653,13 @@ snapshots:
 
   metro-runtime@0.80.12:
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.25.7
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.80.12:
     dependencies:
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.80.12
@@ -15995,10 +16684,10 @@ snapshots:
 
   metro-transform-plugins@0.80.12:
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/generator': 7.25.6
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.6
+      '@babel/core': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/template': 7.25.7
+      '@babel/traverse': 7.25.7
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -16006,10 +16695,10 @@ snapshots:
 
   metro-transform-worker@0.80.12:
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/generator': 7.25.6
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/core': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/types': 7.25.7
       flow-enums-runtime: 0.0.6
       metro: 0.80.12
       metro-babel-transformer: 0.80.12
@@ -16026,13 +16715,13 @@ snapshots:
 
   metro@0.80.12:
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/core': 7.25.2
-      '@babel/generator': 7.25.6
-      '@babel/parser': 7.25.6
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/code-frame': 7.25.7
+      '@babel/core': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/template': 7.25.7
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -17042,6 +17731,10 @@ snapshots:
     dependencies:
       regenerate: 1.4.2
 
+  regenerate-unicode-properties@10.2.0:
+    dependencies:
+      regenerate: 1.4.2
+
   regenerate@1.4.2: {}
 
   regenerator-runtime@0.13.11: {}
@@ -17069,9 +17762,24 @@ snapshots:
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
 
+  regexpu-core@6.1.1:
+    dependencies:
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.0
+      regjsgen: 0.8.0
+      regjsparser: 0.11.1
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.0
+
+  regjsgen@0.8.0: {}
+
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
+
+  regjsparser@0.11.1:
+    dependencies:
+      jsesc: 3.0.2
 
   regjsparser@0.9.1:
     dependencies:
@@ -17156,30 +17864,30 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rollup@2.79.1:
+  rollup@2.79.2:
     optionalDependencies:
       fsevents: 2.3.3
 
-  rollup@4.21.3:
+  rollup@4.24.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.21.3
-      '@rollup/rollup-android-arm64': 4.21.3
-      '@rollup/rollup-darwin-arm64': 4.21.3
-      '@rollup/rollup-darwin-x64': 4.21.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.21.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.21.3
-      '@rollup/rollup-linux-arm64-gnu': 4.21.3
-      '@rollup/rollup-linux-arm64-musl': 4.21.3
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.21.3
-      '@rollup/rollup-linux-s390x-gnu': 4.21.3
-      '@rollup/rollup-linux-x64-gnu': 4.21.3
-      '@rollup/rollup-linux-x64-musl': 4.21.3
-      '@rollup/rollup-win32-arm64-msvc': 4.21.3
-      '@rollup/rollup-win32-ia32-msvc': 4.21.3
-      '@rollup/rollup-win32-x64-msvc': 4.21.3
+      '@rollup/rollup-android-arm-eabi': 4.24.0
+      '@rollup/rollup-android-arm64': 4.24.0
+      '@rollup/rollup-darwin-arm64': 4.24.0
+      '@rollup/rollup-darwin-x64': 4.24.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.24.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.24.0
+      '@rollup/rollup-linux-arm64-gnu': 4.24.0
+      '@rollup/rollup-linux-arm64-musl': 4.24.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.24.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.24.0
+      '@rollup/rollup-linux-s390x-gnu': 4.24.0
+      '@rollup/rollup-linux-x64-gnu': 4.24.0
+      '@rollup/rollup-linux-x64-musl': 4.24.0
+      '@rollup/rollup-win32-arm64-msvc': 4.24.0
+      '@rollup/rollup-win32-ia32-msvc': 4.24.0
+      '@rollup/rollup-win32-x64-msvc': 4.24.0
       fsevents: 2.3.3
 
   run-async@3.0.0: {}
@@ -17924,6 +18632,8 @@ snapshots:
 
   unicode-match-property-value-ecmascript@2.1.0: {}
 
+  unicode-match-property-value-ecmascript@2.2.0: {}
+
   unicode-property-aliases-ecmascript@2.1.0: {}
 
   union-value@1.0.1:
@@ -17983,6 +18693,12 @@ snapshots:
       browserslist: 4.23.3
       escalade: 3.1.2
       picocolors: 1.0.1
+
+  update-browserslist-db@1.1.1(browserslist@4.24.0):
+    dependencies:
+      browserslist: 4.24.0
+      escalade: 3.2.0
+      picocolors: 1.1.0
 
   uri-js@4.4.1:
     dependencies:
@@ -18105,7 +18821,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
-      rollup: 4.21.3
+      rollup: 4.24.0
     optionalDependencies:
       '@types/node': 20.16.10
       fsevents: 2.3.3
@@ -18277,10 +18993,10 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
       '@babel/runtime': 7.25.6
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.1)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.1)
-      '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@2.79.1)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.2)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.2)
+      '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
+      '@rollup/plugin-terser': 0.4.4(rollup@2.79.2)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.12.0
       common-tags: 1.8.2
@@ -18289,7 +19005,7 @@ snapshots:
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.79.1
+      rollup: 2.79.2
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1

--- a/web/src/components/Accordion.tsx
+++ b/web/src/components/Accordion.tsx
@@ -1,5 +1,10 @@
-import { ChevronDown, ChevronUp, LucideIcon } from 'lucide-react';
+import { animated, useSpring } from '@react-spring/web';
+import { ChevronRight, LucideIcon } from 'lucide-react';
+import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+import useResizeObserver from 'use-resize-observer';
+
+const AnimatedIcon = animated<LucideIcon>(ChevronRight);
 
 export default function Accordion({
   onClick,
@@ -10,8 +15,8 @@ export default function Accordion({
   children,
   title,
   expandedTitle,
-  collapsedIcon = ChevronUp,
-  expandedIcon = ChevronDown,
+  collapsedIcon,
+  expandedIcon,
   iconClassName,
   iconSize = 24,
   isCollapsed,
@@ -34,18 +39,55 @@ export default function Accordion({
   setState: (isCollapsed: boolean) => void;
   isTopExpanding?: boolean;
 }) {
+  const { ref, height: observerHeight } = useResizeObserver<HTMLDivElement>();
+  const [renderChildren, setRenderChildren] = useState(!isCollapsed);
+
+  const [spring, api] = useSpring(
+    () => ({
+      height: isCollapsed ? 0 : observerHeight,
+      // eslint-disable-next-line unicorn/no-nested-ternary -- it interferes with prettier
+      rotate: isCollapsed ? (isTopExpanding ? -90 : 90) : isTopExpanding ? 90 : -90,
+    }),
+    [isCollapsed, isTopExpanding, observerHeight]
+  );
+
   const handleToggleCollapse = () => {
     onClick?.();
+    setRenderChildren(true);
 
-    isCollapsed && onOpen?.();
+    if (isCollapsed) {
+      onOpen?.();
+
+      api.start({
+        to: {
+          height: observerHeight,
+          rotate: isTopExpanding ? 90 : -90,
+        },
+      });
+    } else {
+      api.start({
+        to: {
+          height: 0,
+          rotate: isTopExpanding ? -90 : 90,
+        },
+        onRest: () => {
+          setRenderChildren(false);
+        },
+      });
+    }
 
     setState(!isCollapsed);
   };
 
-  const Icon: LucideIcon = isTopExpanding === isCollapsed ? collapsedIcon : expandedIcon;
+  // Temporary workaround to allow for custom icons to be used (which will not be animated)
+  // We will remove this once we have a alternative solution
+  const Icon: LucideIcon =
+    (collapsedIcon && expandedIcon && isTopExpanding === isCollapsed // Only use the custom icons if they are both provided and invert them if the accordion is top expanding
+      ? collapsedIcon
+      : expandedIcon) ?? ChevronRight; // The default icon here is just to satisfy the type checker
 
   return (
-    <section className="flex flex-col gap-1.5 py-1">
+    <section className="flex flex-col overflow-hidden py-1">
       <button
         data-test-id="collapse-button"
         onClick={handleToggleCollapse}
@@ -56,13 +98,27 @@ export default function Accordion({
           {(expandedTitle && !isCollapsed ? expandedTitle : title) || title}
         </h3>
         {badge}
-        <Icon
-          className={twMerge('text-black dark:text-white', iconClassName)}
-          data-test-id={isCollapsed ? 'collapse-down' : 'collapse-up'}
-          size={iconSize}
-        />
+        {collapsedIcon && expandedIcon ? (
+          <Icon
+            className={twMerge('text-black dark:text-white', iconClassName)}
+            data-test-id={isCollapsed ? 'collapse-down' : 'collapse-up'}
+            size={iconSize}
+          />
+        ) : (
+          <AnimatedIcon
+            className={twMerge('text-black dark:text-white', iconClassName)}
+            style={{ rotate: spring.rotate.to((r) => `${r}deg`) }}
+            data-test-id={isCollapsed ? 'collapse-down' : 'collapse-up'}
+            size={iconSize}
+          />
+        )}
       </button>
-      {!isCollapsed && <div>{children}</div>}
+      <animated.div style={{ height: spring.height }}>
+        {/* The div below is used to measure the height of the children
+         * DO NOT REMOVE IT
+         */}
+        <div ref={ref}>{renderChildren && children}</div>
+      </animated.div>
     </section>
   );
 }

--- a/web/src/components/MapOverlays.tsx
+++ b/web/src/components/MapOverlays.tsx
@@ -35,7 +35,7 @@ export default function MapOverlays() {
     : () => undefined;
 
   return (
-    <div className="pointer-events-none fixed top-12 z-20 m-3 flex flex-col items-end space-y-3 sm:bottom-0 sm:right-0 sm:top-auto ">
+    <div className="pointer-events-none fixed top-12 z-10 m-3 flex flex-col items-end space-y-3 sm:bottom-0 sm:right-0 sm:top-auto ">
       {isBiggerThanMobile && (
         <>
           {showManager && (

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -95,7 +95,7 @@ export const Toast = forwardRef<ToastController, ToastProps>(function Toast(
         duration={duration}
         type="background"
         className={twMerge(
-          'fixed left-1/2 top-16 z-50 flex w-11/12 min-w-fit max-w-sm -translate-x-1/2 transform rounded-lg shadow',
+          'fixed left-1/2 top-16 z-40 flex w-11/12 min-w-fit max-w-sm -translate-x-1/2 transform rounded-lg shadow',
           'border border-solid border-neutral-50 bg-white/80 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900',
           "before:content[''] before:absolute before:block before:h-full before:w-1 before:rounded-bl-md before:rounded-tl-md",
           color,

--- a/web/src/components/modals/OnboardingModalInner.tsx
+++ b/web/src/components/modals/OnboardingModalInner.tsx
@@ -56,7 +56,7 @@ function Modal({
   return (
     <>
       <div
-        className="absolute inset-0 z-40 bg-gray-800/20"
+        className="absolute inset-0 z-50 bg-gray-800/20"
         onClick={onDismiss}
         onKeyDown={onDismiss}
         role="presentation"

--- a/web/src/features/charts/FuturePrice.cy.tsx
+++ b/web/src/features/charts/FuturePrice.cy.tsx
@@ -60,6 +60,8 @@ describe('FuturePrice negative values', () => {
   });
 
   it('Price data is visible', () => {
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="collapse-button"]').click();
     cy.get('[data-test-id="negative-price"]').should('be.visible');
     cy.get('[data-test-id="price-bar"]').should('be.visible');
     cy.get('[data-test-id="positive-price"]').should('be.visible');

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -63,7 +63,7 @@ export default function Header(): JSX.Element {
   return (
     <header
       className={twMerge(
-        'z-30 hidden w-full items-center justify-between bg-white px-4 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)] md:pr-4',
+        'z-40 hidden w-full items-center justify-between bg-white px-4 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)] md:pr-4',
         !isMobileApp && 'sm:block md:flex'
       )}
     >

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -109,7 +109,7 @@ function DesktopMapControls() {
   };
 
   return (
-    <div className="pointer-events-none absolute right-3 top-2 z-30 hidden flex-col items-end md:flex">
+    <div className="pointer-events-none absolute right-3 top-2 z-20 hidden flex-col items-end md:flex">
       <div className="pointer-events-auto mb-16 flex flex-col items-end space-y-2">
         <ConsumptionProductionToggle />
         <SpatialAggregatesToggle />

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -74,7 +74,7 @@ function CollapseButton({ isCollapsed, onCollapse }: CollapseButtonProps) {
     <button
       data-test-id="left-panel-collapse-button"
       className={
-        'absolute left-full top-2 z-10 h-12 w-6 cursor-pointer rounded-r bg-zinc-50 shadow-[6px_2px_10px_-3px_rgba(0,0,0,0.1)] hover:bg-zinc-100 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'
+        'absolute left-full top-2 z-[21] h-12 w-6 cursor-pointer rounded-r bg-zinc-50 shadow-[6px_2px_10px_-3px_rgba(0,0,0,0.1)] hover:bg-zinc-100 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'
       }
       onClick={onCollapse}
       aria-label={
@@ -105,7 +105,7 @@ function OuterPanel({ children }: { children: React.ReactNode }) {
   return (
     <div
       data-test-id="left-panel"
-      className={`absolute left-0 top-0 z-20 h-full w-full bg-zinc-50 shadow-xl transition-all duration-500 dark:bg-gray-900 dark:[color-scheme:dark] sm:flex sm:w-[calc(14vw_+_16rem)] ${
+      className={`absolute left-0 top-0 z-[21] h-full w-full bg-zinc-50 shadow-xl transition-all duration-500 dark:bg-gray-900 dark:[color-scheme:dark] sm:flex sm:w-[calc(14vw_+_16rem)] ${
         location.pathname === '/map' ? 'hidden' : ''
       } ${isOpen ? '' : '-translate-x-full'}`}
     >

--- a/web/src/features/time/TimeControllerWrapper.tsx
+++ b/web/src/features/time/TimeControllerWrapper.tsx
@@ -39,7 +39,7 @@ function BottomSheetWrappedTimeController() {
 
 function FloatingTimeController() {
   return (
-    <div className="fixed bottom-3 left-3 z-20 w-[calc(14vw_+_16rem)] rounded-xl bg-white px-4 py-3 shadow-xl drop-shadow-2xl dark:bg-gray-800 min-[780px]:w-[calc((14vw_+_16rem)_-_30px)] xl:px-5">
+    <div className="fixed bottom-3 left-3 z-30 w-[calc(14vw_+_16rem)] rounded-xl bg-white px-4 py-3 shadow-xl drop-shadow-2xl dark:bg-gray-800 min-[780px]:w-[calc((14vw_+_16rem)_-_30px)] xl:px-5">
       <TimeController />
     </div>
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -24,32 +24,39 @@
     @apply text-gray-900 dark:text-gray-200;
     /* Disables mobile touch specific blue user select effect */
     -webkit-tap-highlight-color: transparent;
-  }
-  h1 {
-    @apply text-xl;
-    @apply font-poppins;
-    @apply font-medium;
-  }
-  h2 {
-    @apply text-base;
-    @apply font-poppins;
-    @apply font-medium;
-  }
-  h3 {
-    @apply text-sm;
-    @apply font-poppins;
-    @apply font-medium;
-  }
-  h4 {
-    @apply text-xs;
-    @apply font-poppins;
-    @apply font-medium;
-  }
-  p {
-    @apply text-sm;
-    @apply font-inter;
+
+    /* Added safe area insets for iOS */
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
   }
 }
+h1 {
+  @apply text-xl;
+  @apply font-poppins;
+  @apply font-medium;
+}
+h2 {
+  @apply text-base;
+  @apply font-poppins;
+  @apply font-medium;
+}
+h3 {
+  @apply text-sm;
+  @apply font-poppins;
+  @apply font-medium;
+}
+h4 {
+  @apply text-xs;
+  @apply font-poppins;
+  @apply font-medium;
+}
+p {
+  @apply text-sm;
+  @apply font-inter;
+}
+
 *::-webkit-scrollbar {
   /*remove scrollbar track chrome*/
   background-color: transparent;


### PR DESCRIPTION
### **iOS header overlaps with UI (Fixed):**
fix: resolve iOS header overlap by adding safe area insets to CSS

---

### **Description:**

This PR resolves the issue where the iOS header (time, date, battery, etc.) overlaps with the UI when the app is viewed on iPads. The problem stems from the layout not considering the iOS-specific safe area insets.

- Added CSS safe area insets (`env(safe-area-inset-*)`) to ensure proper padding for iOS devices.
- Adjusted `padding-top`, `padding-bottom`, and side insets for better alignment and to prevent header overlap.
- Maintained the integrity of existing styles while applying the necessary layout fixes.

---

### **Preview:**

Please find below a screenshot demonstrating the resolution of the issue:

<img width="416" alt="373942909-946e6ccf-916e-4ad6-96c6-3c046f8de167" src="https://github.com/user-attachments/assets/6ad8a0dc-668f-4b71-a565-260ceb353c56">


---

### **Double Check:**

- [x] I have tested my changes on an iOS device (iPad).
- [x] I have verified that the safe area insets do not affect non-iOS devices.

